### PR TITLE
Add colon (:) to trusted characters (for "Code::Blocks" appmenu)

### DIFF
--- a/appmenus-scripts/qubes-receive-appmenus
+++ b/appmenus-scripts/qubes-receive-appmenus
@@ -44,7 +44,7 @@ appmenus_line_size = 1024
 appmenus_line_count = 100000
 
 # regexps for sanitization of retrieved values
-std_re = re.compile(r"^[/a-zA-Z0-9.,&()_ -]*$")
+std_re = re.compile(r"^[/a-zA-Z0-9.,:&()_ -]*$")
 fields_regexp = {
     "Name": std_re,
     "GenericName": std_re,


### PR DESCRIPTION
After installing "codeblocks" app in TemplateVM it doesn't appear in Qubes VM Manager's available app shortcuts.
If I run in a Dom0 Terminal: /usr/libexec/qubes-appmenus/qubes-receive-appmenus fedora-23
I get this: "Warning: ignoring key 'Name' of codeblocks.desktop"
The "Name" key in that file has value "Code::Blocks"

The problem comes from line 168, because of the colons in the app Name.

By adding the colon ":" to the std_re used to match valid characters for "Name", the app is correctly parsed and I can add the shortcut to AppVMs