### PR TITLE
Support in-place template reinstalls - for testing

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -63,9 +63,11 @@ done
 
 # Prevent template upgrade - this would override user changes -
 # but do allow explicit template reinstalls
-if [ "$YUM_ACTION" == "reinstall" ] ; then
+if [ "$YUM_ACTION" == "reinstall" ] && [[ "$PKGS" == *"qubes-template-"* ]]; then
     TEMPLATE_EXCLUDE_OPTS=""
-else TEMPLATE_EXCLUDE_OPTS="--exclude=`rpm -qa --qf '%{NAME},' qubes-template-\*`"
+    echo "WARNING: Reinstalling a template will erase files in /home and /rw !"
+else
+    TEMPLATE_EXCLUDE_OPTS="--exclude=`rpm -qa --qf '%{NAME},' qubes-template-\*`"
 fi
 YUM_OPTS="$TEMPLATE_EXCLUDE_OPTS $YUM_OPTS"
 ALL_OPTS="$TEMPLATE_EXCLUDE_OPTS $ALL_OPTS"

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -68,12 +68,12 @@ if [ "$YUM_ACTION" == "reinstall" ] && [[ "$PKGS" == *"qubes-template-"* ]]; the
     echo "WARNING: Reinstalling a template will erase files in /home and /rw !"
     
     $ONEPKG=`cut -f 1 -d ' ' <<<$PKGS`
-    if [[ "$ONEPKG" == "qubes-template-"* ]] ; then
+    if [[ "$ONEPKG" == "qubes-template-"* ]] && [[ "$ONEPKG" == "${PKGS#\ }" ]]; then # test "$PKGS" minus space
     # Prepare to backup template root.img in case reinstall doesn't complete.
         TEMPLATE=${ONEPKG#qubes-template-}
         BAK_TEMPLATE_ROOT=`qvm-prefs $TEMPLATE root_img` || exit 1
     else
-        echo "ERROR: Specify only one template package for reinstall"
+        echo "ERROR: Specify only one package to reinstall template"
         exit 1
     fi
             
@@ -201,6 +201,7 @@ elif [ -f /var/lib/qubes/updates/repodata/repomd.xml ]; then
             
             if [ $RETCODE -eq 0 ] && [[ -n "$BAK_TEMPLATE_ROOT" ]] ; then
             # Reinstall went OK, remove backup file.
+                echo "Removing $BAK_TEMPLATE_ROOT-bak"
                 rm -f "$BAK_TEMPLATE_ROOT-bak"
             fi
         fi

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -71,6 +71,8 @@ if [ "$YUM_ACTION" == "reinstall" ] && [[ "$PKGS" == *"qubes-template-"* ]]; the
     if [[ "$ONEPKG" == "qubes-template-"* ]] && [[ "$ONEPKG" == "${PKGS#\ }" ]]; then # test "$PKGS" minus space
     # Prepare to backup template root.img in case reinstall doesn't complete.
         TEMPLATE=${ONEPKG#qubes-template-}
+        TEMPLATE_NETVM=`qvm-prefs $TEMPLATE netvm` || exit 1
+        if [[ "$TEMPLATE_NETVM" == *"(default)" ]] ; then TEMPLATE_NETVM="default"
         BAK_TEMPLATE_ROOT=`qvm-prefs $TEMPLATE root_img` || exit 1
     else
         echo "ERROR: Specify only one package to reinstall template"
@@ -199,10 +201,13 @@ elif [ -f /var/lib/qubes/updates/repodata/repomd.xml ]; then
 
             yum $YUM_OPTS $YUM_ACTION ; RETCODE=$?
             
-            if [ $RETCODE -eq 0 ] && [[ -n "$BAK_TEMPLATE_ROOT" ]] ; then
-            # Reinstall went OK, remove backup file.
-                echo "Removing $BAK_TEMPLATE_ROOT-bak"
-                rm -f "$BAK_TEMPLATE_ROOT-bak"
+            if [[ -n "$BAK_TEMPLATE_ROOT" ]] ; then
+                qvm-prefs -s $TEMPLATE netvm $TEMPLATE_NETVM
+                if [ $RETCODE -eq 0 ] ; then
+                # Reinstall went OK, remove backup file.
+                    echo "Removing $BAK_TEMPLATE_ROOT-bak"
+                    rm -f "$BAK_TEMPLATE_ROOT-bak"
+                fi
             fi
         fi
     fi

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -66,6 +66,17 @@ done
 if [ "$YUM_ACTION" == "reinstall" ] && [[ "$PKGS" == *"qubes-template-"* ]]; then
     TEMPLATE_EXCLUDE_OPTS=""
     echo "WARNING: Reinstalling a template will erase files in /home and /rw !"
+    
+    $ONEPKG=`cut -f 1 -d ' ' <<<$PKGS`
+    if [[ "$ONEPKG" == "qubes-template-"* ]] ; then
+    # Prepare to backup template root.img in case reinstall doesn't complete.
+        TEMPLATE=${ONEPKG#qubes-template-}
+        BAK_TEMPLATE_ROOT=`qvm-prefs $TEMPLATE root_img` || exit 1
+    else
+        echo "ERROR: Specify only one template package for reinstall"
+        exit 1
+    fi
+            
 else
     TEMPLATE_EXCLUDE_OPTS="--exclude=`rpm -qa --qf '%{NAME},' qubes-template-\*`"
 fi
@@ -173,8 +184,25 @@ elif [ -f /var/lib/qubes/updates/repodata/repomd.xml ]; then
         $guiapp
     else
         yum check-update
-        if [ $? -eq 100 ]; then
-            yum $YUM_OPTS $YUM_ACTION
+        if [ $? -eq 100 ]; then # Run yum with options
+
+            if [[ -n "$BAK_TEMPLATE_ROOT" ]] ; then
+            # Backup root.img just in case
+                echo -n "Renaming template root.img to root.img-bak..."
+                if mv "$BAK_TEMPLATE_ROOT" "$BAK_TEMPLATE_ROOT-bak" ; then
+                    echo "OK"
+                else
+                    echo; echo "ERROR: Could not rename root.img"
+                    exit 1
+                fi
+            fi
+
+            yum $YUM_OPTS $YUM_ACTION ; RETCODE=$?
+            
+            if [ $RETCODE -eq 0 ] && [[ -n "$BAK_TEMPLATE_ROOT" ]] ; then
+            # Reinstall went OK, remove backup file.
+                rm -f "$BAK_TEMPLATE_ROOT-bak"
+            fi
         fi
     fi
     yum -q check-update && rm -f $UPDATES_STAT_FILE

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -22,13 +22,11 @@ if [ "$1" = "--help" ]; then
     exit
 fi
 
-# Prevent template upgrade - this would override user changes
-TEMPLATE_EXCLUDE_OPTS="--exclude=`rpm -qa --qf '%{NAME},' qubes-template-\*`"
 PKGS=
-YUM_OPTS="$TEMPLATE_EXCLUDE_OPTS"
+YUM_OPTS=
 GUI=
 CHECK_ONLY=
-ALL_OPTS="$TEMPLATE_EXCLUDE_OPTS $*"
+ALL_OPTS="$*"
 YUM_ACTION=
 QVMRUN_OPTS=
 CLEAN=
@@ -62,6 +60,15 @@ while [ $# -gt 0 ]; do
     esac
     shift
 done
+
+# Prevent template upgrade - this would override user changes -
+# but do allow explicit template reinstalls
+if [ "$YUM_ACTION" == "reinstall" ] ; then
+    TEMPLATE_EXCLUDE_OPTS=""
+else TEMPLATE_EXCLUDE_OPTS="--exclude=`rpm -qa --qf '%{NAME},' qubes-template-\*`"
+fi
+YUM_OPTS="$TEMPLATE_EXCLUDE_OPTS $YUM_OPTS"
+ALL_OPTS="$TEMPLATE_EXCLUDE_OPTS $ALL_OPTS"
 
 ID=$(id -ur)
 if [ $ID != 0 -a -z "$GUI" -a -z "$CHECK_ONLY" ] ; then


### PR DESCRIPTION
This doesn't yet prevent appvms from starting with invalid template during the reinstall, and doesn't deal with the Netvm setting problem.
For issue #2061