### PR TITLE
qrexec-client: Also allow the bell character

### DIFF
--- a/qrexec/qrexec-client.c
+++ b/qrexec/qrexec-client.c
@@ -342,7 +342,8 @@ void do_replace_chars(char *buf, int len) {
 		    (c != '\t') &&                 /* not tab */
 		    (c != '\n') &&                 /* not newline */
 		    (c != '\r') &&                 /* not return */
-		    (c != '\b'))                   /* not backspace */
+		    (c != '\b') &&                 /* not backspace */
+		    (c != '\a'))                   /* not bell */
 			buf[i] = '_';
 	}
 }


### PR DESCRIPTION
Used by interactive shells and such. For example, I've saved the following as `qvm-shell` in dom0 to get an alright interactive VM shell with tab completion:

```
#!/bin/sh -e

if test $# = 0; then
    echo "Usage: ${0##*/} [<qvm-run argument>...] <vm>" >&2
    exit 1
fi

if test -t 0; then
    stty_bak=$(stty -g)
    trap "stty $stty_bak" EXIT
    stty -echo -icanon  # disable echoing and line buffering
fi

qvm-run --pass-io "$@" \
        "LC_ALL=C exec script --quiet --return /dev/null"  # fake a dumb TTY
```