### PR TITLE
qubes-dom0-update: Show sync and download progress

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -165,7 +165,7 @@ qvm-run $QVMRUN_OPTS -a $UPDATEVM true || exit 1
 tar c /var/lib/rpm /etc/yum.repos.d /etc/yum.conf 2>/dev/null | \
    qvm-run -p "$UPDATEVM" 'LC_MESSAGES=C tar x -C /var/lib/qubes/dom0-updates 2>&1 | grep -v -E "s in the future"'
 
-qvm-run $QVMRUN_OPTS --pass-io $UPDATEVM "/usr/lib/qubes/qubes-download-dom0-updates.sh --doit --nogui $ALL_OPTS"
+qvm-run $QVMRUN_OPTS --pass-io $UPDATEVM "script --quiet --return --command '/usr/lib/qubes/qubes-download-dom0-updates.sh --doit --nogui $ALL_OPTS' /dev/null"
 RETCODE=$?
 if [ "$CHECK_ONLY" == "1" ]; then
     exit $RETCODE


### PR DESCRIPTION
Use `script` (part of util-linux) to fake a dumb terminal in the updatevm, so dnf will show sync and download progress indicators.