### PR TITLE
Ignore EFI boot args when parsing for filename

### DIFF
--- a/system-config/kernel-xen-efi.install
+++ b/system-config/kernel-xen-efi.install
@@ -12,7 +12,7 @@ EFI_DIR=$(efibootmgr -v 2>/dev/null | awk '
         /^Boot....\* / { 
             if ("Boot" current "*" == $1) {
                 sub(".*File\\(", "");
-                sub("\\\\xen.efi\\)", "");
+                sub("\\\\xen.efi\\).*", "");
                 gsub("\\\\", "/");
                 print;
             }


### PR DESCRIPTION
I need to set some flags in order to boot as described here: https://www.qubes-os.org/doc/uefi-troubleshooting/

My settings look like this:
```
    $ efibootmgr -v
    BootCurrent: 0000
    Boot0000* Qubes HD(...)/File(\EFI\qubes\xen.efi)p.l.a.c.e.h.o...
```

which causes awk to get confused and think my $EFI_DIR should be:
```
    /EFI/qubesp.l.a.c.e.h.o.l.d.e.r. ./.m.a.p.b.s. ./.n.o.e.x.i.t.b.o.o.t.
```

This causes the script to later bail:
```
    if [ ! -d "$EFI_DIR" ]; then
        # non-EFI system
        exit 0;
    fi
```

So my xen.cfg did not get new entries when installing dom0 kernel packages.