### PR TITLE
(dom0) qvm-move-to-vm: don't "rm -rf" vm name argument

### DIFF
--- a/file-copy-vm/qvm-move-to-vm
+++ b/file-copy-vm/qvm-move-to-vm
@@ -21,4 +21,5 @@
 #
 
 . qvm-copy-to-vm "$@" &&
+shift &&
 rm -rf -- "$@"


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#2472 from commit
bc29af7c0c5f1a48a17d2218e807497711af181d