### PR TITLE
dracut: Do not fail if Xen components are built into the kernel

### DIFF
--- a/dracut/modules.d/90qubes-pciback/installkernel
+++ b/dracut/modules.d/90qubes-pciback/installkernel
@@ -1,3 +1,7 @@
 #!/bin/bash
-modinfo -k $kernel pciback > /dev/null 2>&1 && instmods pciback
-modinfo -k $kernel xen-pciback > /dev/null 2>&1 && instmods xen-pciback
+
+for mod in pciback xen-pciback; do
+    if modinfo -k "${kernel}" "${mod}" >/dev/null 2>&1; then
+        instmods "${mod}"
+    fi
+done

--- a/dracut/modules.d/90qubes-pciback/module-setup.sh
+++ b/dracut/modules.d/90qubes-pciback/module-setup.sh
@@ -8,6 +8,11 @@ install() {
 }
 
 installkernel() {
-    modinfo -k $kernel pciback > /dev/null 2>&1 && hostonly='' instmods pciback
-    modinfo -k $kernel xen-pciback > /dev/null 2>&1 && hostonly='' instmods xen-pciback
+    local mod=
+
+    for mod in pciback xen-pciback; do
+        if modinfo -k "${kernel}" "${mod}" >/dev/null 2>&1; then
+            hostonly='' instmods "${mod}"
+        fi
+    done
 }


### PR DESCRIPTION
Prior to this commit, if the Linux kernel's Xen-related components were
built into the kernel (as opposed to the use of kernel modules), then
the dracut module initialization would fail during the generation of the
initial ramdisk image.

This commit corrects this issue by using an if/then block.

Signed-off-by: M. Vefa Bicakci <m.v.b@runbox.com>