### PR TITLE
.desktop parsing (receive appmenus) misc fixes

### DIFF
--- a/appmenus-scripts/qubes-receive-appmenus
+++ b/appmenus-scripts/qubes-receive-appmenus
@@ -50,7 +50,7 @@ fields_regexp = {
     "GenericName": std_re,
     "Comment": std_re,
     "Categories": re.compile(r"^[a-zA-Z0-9/.;:'() -]*$"),
-    "Exec": re.compile(r"^[a-zA-Z0-9()_%&>/{}\"'\\:.= -]*$"),
+    "Exec": re.compile(r"^[a-zA-Z0-9()_&>/{}\"'\\:.= -]*$"),
     "Icon": re.compile(r"^[a-zA-Z0-9/_.-]*$"),
 }
 
@@ -142,8 +142,8 @@ def get_appmenus(vm):
 
     appmenus = {}
     line_rx = re.compile(
-        r"([a-zA-Z0-9.()_-]+.desktop):([a-zA-Z0-9-]+(?:\[[a-zA-Z@_]+\])?)=(.*)")
-    ignore_rx = re.compile(r".*([a-zA-Z0-9._-]+.desktop):(#.*|\s+)$")
+        r"([a-zA-Z0-9._-]+\.desktop):([a-zA-Z0-9-]+(?:\[[a-zA-Z@_]+\])?)=(.*)")
+    ignore_rx = re.compile(r".*([a-zA-Z0-9._-]+\.desktop):(#.*|\s*)$")
     for untrusted_line in untrusted_appmenulist:
         # Ignore blank lines and comments
         if len(untrusted_line) == 0 or ignore_rx.match(untrusted_line):


### PR DESCRIPTION
- Make `.desktop` match only `.desktop` and not `[wildcard character] desktop`

- Remove () from the list of accepted characters (this seemed to be causing trouble, do we need it?)

- Remove `%` from the whitelist of allowed characters in .desktop->Exec since the `%` character is interpreted as an escape by the [Desktop Entry specification](https://www.freedesktop.org/wiki/Specifications/desktop-entry-spec/), but not by the `pipes.quote()` function used to escape the string, which allows TemplateVMs to break out of the intended shell escaping.

- Change whitespace match for `ignore_rx` to have empty lines from the Desktop Entry files excluded.

Thanks to @DonnchaC for working with me on this.