### PR TITLE
Improve qrexec protocol mismatch error dialog

### DIFF
--- a/qrexec/qrexec-daemon.c
+++ b/qrexec/qrexec-daemon.c
@@ -167,16 +167,16 @@ static void incompatible_protocol_error_message(
     int ret;
     struct stat buf;
     ret=stat("/usr/bin/kdialog", &buf);
-#define KDIALOG_CMD "kdialog --title 'Qrexec daemon' --warningyesno "
-#define ZENITY_CMD "zenity --title 'Qrexec daemon' --question --text "
+#define KDIALOG_CMD "kdialog --title 'Qrexec daemon' --sorry "
+#define ZENITY_CMD "zenity --title 'Qrexec daemon' --warning --text "
     snprintf(text, sizeof(text),
             "%s"
             "'Domain %s uses incompatible qrexec protocol (%d instead of %d). "
             "You need to update either dom0 or VM packages.\n"
-            "To access this VM console do not close this error message and call:\n"
-            "sudo xl console vmname'",
+            "To access this VM console do not close this error message and run:\n"
+            "sudo xl console -t pv %s'",
             ret==0 ? KDIALOG_CMD : ZENITY_CMD,
-            domain_name, remote_version, QREXEC_PROTOCOL_VERSION);
+            domain_name, remote_version, QREXEC_PROTOCOL_VERSION, domain_name);
 #undef KDIALOG_CMD
 #undef ZENITY_CMD
     system(text);


### PR DESCRIPTION
- only have one button, because "yes/no" makes no sense in this context
- inform use to use "-t pv" for xl console, because otherwise it won't
  work for HVM domains.
- use the actual VM name, not "vmname"

## kdialog
before:
![before-kdialog](https://user-images.githubusercontent.com/1231207/33735562-9cdee9fa-db5d-11e7-9d87-59d32b338cd1.png)

after:
![after-kdialog](https://user-images.githubusercontent.com/1231207/33735582-b0531d8a-db5d-11e7-8cee-8ed3df482b40.png)

## zenity
before:
![before-zenity](https://user-images.githubusercontent.com/1231207/33735571-a6fe82e2-db5d-11e7-82e8-e484ddb6ffca.png)

after:
![after-zenity](https://user-images.githubusercontent.com/1231207/33735587-b5da80b8-db5d-11e7-8402-04b9fdce6e34.png)
