### PR TITLE
Fix fall through

### DIFF
--- a/qrexec/qrexec-client.c
+++ b/qrexec/qrexec-client.c
@@ -633,6 +633,7 @@ static void wait_for_vchan_client_with_timeout(libvchan_t *conn, int timeout) {
                     fprintf(stderr, "vchan connection error\n");
                     libvchan_close(conn);
                     do_exit(1);
+                    break;
                 case 0:
                     fprintf(stderr, "vchan connection timeout\n");
                     libvchan_close(conn);


### PR DESCRIPTION
It's necessary to add the break at the end of "case -1" statement else the compiler will treat it as fall through and GCC 7 will throw an error because of -Werror=implicit-fallthrough=.