### PR TITLE
Make dir dom0-updates if not exists on UpdateVM

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -166,7 +166,7 @@ rm -f /var/lib/qubes/updates/errors
 echo "Using $UPDATEVM as UpdateVM to download updates for Dom0; this may take some time..." >&2
 
 # qvm-run by default auto-starts the VM if not running
-qvm-run --nogui -q -u root  $UPDATEVM 'mkdir -m 775 /var/lib/qubes/dom0-updates/' || exit 1
+qvm-run --nogui -q -u root  $UPDATEVM 'mkdir -m 775 -p /var/lib/qubes/dom0-updates/' || exit 1
 qvm-run --nogui -q -u root  $UPDATEVM 'chown user:user /var/lib/qubes/dom0-updates/' || exit 1
 qvm-run --nogui -q $UPDATEVM 'rm -rf /var/lib/qubes/dom0-updates/etc' || exit 1
 tar c /var/lib/rpm /etc/yum.repos.d /etc/yum.conf 2>/dev/null | \

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -166,6 +166,8 @@ rm -f /var/lib/qubes/updates/errors
 echo "Using $UPDATEVM as UpdateVM to download updates for Dom0; this may take some time..." >&2
 
 # qvm-run by default auto-starts the VM if not running
+qvm-run --nogui -q -u root  $UPDATEVM 'mkdir -m 775 /var/lib/qubes/dom0-updates/' || exit 1
+qvm-run --nogui -q -u root  $UPDATEVM 'chown user:user /var/lib/qubes/dom0-updates/' || exit 1
 qvm-run --nogui -q $UPDATEVM 'rm -rf /var/lib/qubes/dom0-updates/etc' || exit 1
 tar c /var/lib/rpm /etc/yum.repos.d /etc/yum.conf 2>/dev/null | \
    qvm-run --nogui --pass-io "$UPDATEVM" 'LC_MESSAGES=C tar x -C /var/lib/qubes/dom0-updates 2>&1 | grep -v -E "s in the future"'

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -166,8 +166,8 @@ rm -f /var/lib/qubes/updates/errors
 echo "Using $UPDATEVM as UpdateVM to download updates for Dom0; this may take some time..." >&2
 
 # qvm-run by default auto-starts the VM if not running
-qvm-run --nogui -q -u root  $UPDATEVM 'mkdir -m 775 -p /var/lib/qubes/dom0-updates/' || exit 1
-qvm-run --nogui -q -u root  $UPDATEVM 'chown user:user /var/lib/qubes/dom0-updates/' || exit 1
+qvm-run --nogui -q -u root $UPDATEVM 'mkdir -m 775 -p /var/lib/qubes/dom0-updates/' || exit 1
+qvm-run --nogui -q -u root $UPDATEVM 'chown user:user /var/lib/qubes/dom0-updates/' || exit 1
 qvm-run --nogui -q $UPDATEVM 'rm -rf /var/lib/qubes/dom0-updates/etc' || exit 1
 tar c /var/lib/rpm /etc/yum.repos.d /etc/yum.conf 2>/dev/null | \
    qvm-run --nogui --pass-io "$UPDATEVM" 'LC_MESSAGES=C tar x -C /var/lib/qubes/dom0-updates 2>&1 | grep -v -E "s in the future"'


### PR DESCRIPTION
If for whatever reason UpdateVM misses "/var/lib/qubes/dom0-updates", dom0 updates fail.

https://github.com/QubesOS/qubes-issues/issues/3620