### PR TITLE
Make dir dom0-updates if it not exists on UpdateVM

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -163,7 +163,7 @@ echo "Using $UPDATEVM as UpdateVM to download updates for Dom0; this may take so
 
 # Start VM if not running already
 qvm-run $QVMRUN_OPTS -a $UPDATEVM true || exit 1
-qvm-run -u root  $UPDATEVM 'mkdir -m 775 /var/lib/qubes/dom0-updates/' || exit 1
+qvm-run -u root  $UPDATEVM 'mkdir -m 775 -p /var/lib/qubes/dom0-updates/' || exit 1
 qvm-run -u root  $UPDATEVM 'chown user:user /var/lib/qubes/dom0-updates/' || exit 1
 qvm-run  $UPDATEVM 'rm -rf /var/lib/qubes/dom0-updates/etc' || exit 1
 tar c /var/lib/rpm /etc/yum.repos.d /etc/yum.conf 2>/dev/null | \

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -163,6 +163,8 @@ echo "Using $UPDATEVM as UpdateVM to download updates for Dom0; this may take so
 
 # Start VM if not running already
 qvm-run $QVMRUN_OPTS -a $UPDATEVM true || exit 1
+qvm-run -u root  $UPDATEVM 'mkdir -m 775 /var/lib/qubes/dom0-updates/' || exit 1
+qvm-run -u root  $UPDATEVM 'chown user:user /var/lib/qubes/dom0-updates/' || exit 1
 qvm-run  $UPDATEVM 'rm -rf /var/lib/qubes/dom0-updates/etc' || exit 1
 tar c /var/lib/rpm /etc/yum.repos.d /etc/yum.conf 2>/dev/null | \
    qvm-run -p "$UPDATEVM" 'LC_MESSAGES=C tar x -C /var/lib/qubes/dom0-updates 2>&1 | grep -v -E "s in the future"'


### PR DESCRIPTION
If for whatever reason /var/lib/qubes/dom0-updates was deleted or not created dom0 updates fail.

https://github.com/QubesOS/qubes-issues/issues/3620