### PR TITLE
kernel-install: avoid creating initramfs multiple times

### DIFF
--- a/system-config/kernel-grub2.install
+++ b/system-config/kernel-grub2.install
@@ -2,10 +2,17 @@
 
 COMMAND="$1"
 KVER="$2"
+BOOT_DIR_ABS="$3"
 
 case "$COMMAND" in
     add)
-        dracut -f "/boot/initramfs-${KVER}.img" "$KVER"
+        if [ ! -e "/boot/initramfs-${KVER}.img" ]; then
+            if [ -e "$BOOT_DIR_ABS"/initrd ]; then
+                cp "$BOOT_DIR_ABS"/initrd "/boot/initramfs-${KVER}.img"
+            else
+                dracut "/boot/initramfs-${KVER}.img" "$KVER"
+            fi
+        fi
         ;;
     remove)
         rm -f "/boot/initramfs-${KVER}.img"

--- a/system-config/kernel-xen-efi.install
+++ b/system-config/kernel-xen-efi.install
@@ -77,7 +77,11 @@ case "$COMMAND" in
         fi
 
         cp "/boot/vmlinuz-$KVER" "$EFI_DIR/"
-        dracut -f "$EFI_DIR/initramfs-${KVER}.img" "$KVER"
+        if [ -e "/boot/initramfs-${KVER}.img" ]; then
+            cp -f "/boot/initramfs-${KVER}.img" "$EFI_DIR/"
+        else
+            dracut -f "$EFI_DIR/initramfs-${KVER}.img" "$KVER"
+        fi
         ;;
     remove)
         # don't care about changing default= line - yum should prevent removing


### PR DESCRIPTION
There are multiple places where initramfs can be created:
 - /boot/iniramfs-*.img
 - /boot/$MACHINE_ID/.../initrd (unused on Qubes, but created by Fedora
   scripts)
 - /boot/efi/EFI/.../initramfs-*.img

Do not generate all of those from scratch, but try to reuse existing
image (if exists). Since one dracut call may last even 5 minutes, this
change should greatly reduce installation time.

Fixes QubesOS/qubes-issues#3637