### PR TITLE
Added dummy qvm-move/qvm-copy do dom0

### DIFF
--- a/file-copy-vm/qvm-copy
+++ b/file-copy-vm/qvm-copy
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e -o pipefail
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2015  Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#
+
+echo "${0##*/} is not supported in dom0; use ${0##*/}-to-vm instead."
+
+exit 1

--- a/rpm_spec/core-dom0-linux.spec.in
+++ b/rpm_spec/core-dom0-linux.spec.in
@@ -145,7 +145,9 @@ touch $RPM_BUILD_ROOT/var/lib/qubes/.qubes-exclude-block-devices
 # file copy to VM
 install -m 755 file-copy-vm/qfile-dom0-agent $RPM_BUILD_ROOT/usr/lib/qubes/
 install -m 755 file-copy-vm/qvm-copy-to-vm $RPM_BUILD_ROOT/usr/bin/
+install -m 755 file-copy-vm/qvm-copy $RPM_BUILD_ROOT/usr/bin/
 ln -s qvm-copy-to-vm $RPM_BUILD_ROOT/usr/bin/qvm-move-to-vm
+ln -s qvm-copy $RPM_BUILD_ROOT/usr/bin/qvm-move
 
 ### Documentation
 (cd doc; make DESTDIR=$RPM_BUILD_ROOT install)
@@ -207,6 +209,8 @@ chmod -x /etc/grub.d/10_linux
 # file copy
 /usr/bin/qvm-copy-to-vm
 /usr/bin/qvm-move-to-vm
+/usr/bin/qvm-copy
+/usr/bin/qvm-move
 /usr/lib/qubes/qfile-dom0-agent
 # pm-utils
 /usr/lib64/pm-utils/sleep.d/52qubes-pause-vms


### PR DESCRIPTION
While qvm-move and qvm-copy cannot work in dom0, their
absence is confusing. Thus, stub tools that output message
informing the user that these tools are unavailable and
qvm-move-to-vm/qvm-copy-to-vm should be used instead.

fixes QubesOS/qubes-issues#4021