### PR TITLE
Error in qubes-dom0-update --gui

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -230,6 +230,6 @@ else
     rm -f $UPDATES_STAT_FILE
     echo "No updates available" >&2
     if [ "$GUI" == "1" ]; then
-        zenity --title='Dom0 updates' --text='No updates available'
+        zenity --info --title='Dom0 updates' --text='No updates available'
     fi
 fi


### PR DESCRIPTION
Fixed error with zenity in qubes-dom0-update --gui,
in which zenity was called with insufficient parameters.

fixes QubesOS/qubes-issues#4339