### PR TITLE
Adds info & search actions for template packages

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -95,6 +95,8 @@ if [ "$YUM_ACTION" == "reinstall" ] || [ "$YUM_ACTION" == "upgrade" ] || [ "$YUM
         echo "ERROR: Specify only one package to reinstall template"
         exit 1
     fi
+elif [ "$YUM_ACTION" == "search" ] || [ "$YUM_ACTION" == "info" ]; then # No need to shutdown for search/info
+    TEMPLATE_EXCLUDE_OPTS=""
 else
     TEMPLATE_EXCLUDE_OPTS="--exclude=`rpm -qa --qf '%{NAME},' qubes-template-\*`"
 fi


### PR DESCRIPTION
Now we can do --action=info or --action=search
for a template. This will not shutdown the template and simply
execute search or info command for dnf.

