### PR TITLE
[dom0, initramfs] add roadrunner2/macbook12-spi-driver configuration

### DIFF
--- a/dracut/modules.d/90macbook12-spi-driver/module-setup.sh
+++ b/dracut/modules.d/90macbook12-spi-driver/module-setup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/bash
+# Add roadrunner2/macbook12-spi-driver drivers to initramfs for supporting keyboard, touchpad, touchbar in the MacBooks.
+# Pre-requisite: these drivers need to be included in the Linux kernel package.
+
+check() {
+  grep -q ^MacBook /sys/devices/virtual/dmi/id/product_name || return 255
+}
+
+installkernel() {
+  hostonly='' instmods intel_lpss intel_lpss_pci spi_pxa2xx_platform spi_pxa2xx_pci applespi apple_ib_tb
+}
+
+install() {
+  echo "options apple_ib_tb fnmode=2" >> "${initdir}/etc/modprobe.d/macbook12-spi-driver.conf"
+  echo "options applespi fnremap=1" >> "${initdir}/etc/modprobe.d/macbook12-spi-driver.conf"
+}

--- a/rpm_spec/core-dom0-linux.spec.in
+++ b/rpm_spec/core-dom0-linux.spec.in
@@ -211,6 +211,8 @@ chmod -x /etc/grub.d/10_linux
 %attr(0664,root,qubes) %config(noreplace) /etc/qubes-rpc/policy/qubes.repos.Disable
 # Dracut module
 /etc/dracut.conf.d/*
+%dir %{_dracutmoddir}/90macbook12-spi-driver
+%{_dracutmoddir}/90macbook12-spi-driver/*
 %dir %{_dracutmoddir}/90qubes-pciback
 %{_dracutmoddir}/90qubes-pciback/*
 %dir %{_dracutmoddir}/90extra-modules


### PR DESCRIPTION
A separate commit ``give vaio-fixes breath again`` is included to this PR.
I've back tracked the history, it looks like it was disabled by a mistake [during the refactoring](https://github.com/QubesOS/qubes-core-admin-linux/commit/a2139b95b599a4419e7787e1b37097d310771149#diff-5c2dc0ca076fcfeeae786070f88d5a16).

Not sure if this is the right approach of making these a dependency for qubes-core-dom0-linux package, but that works.

----

Parent PR: https://github.com/QubesOS/qubes-linux-kernel/pull/161
Related issue: https://github.com/QubesOS/qubes-issues/issues/3784