### PR TITLE
qubes-dom0-update: support 'list' and 'search' actions

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -86,6 +86,11 @@ while [ $# -gt 0 ]; do
     shift
 done
 
+REMOTE_ONLY=
+if [ "CHECK_ONLY" == "1" ] || [ "$YUM_ACTION" == "list" ] || [ "$YUM_ACTION" == "search" ]; then
+    REMOTE_ONLY=1
+fi
+
 # Prevent implicit update of template - this would override user changes -
 # but do allow explicit template upgrade, downgrade, reinstall
 if [ "$YUM_ACTION" == "reinstall" ] || [ "$YUM_ACTION" == "upgrade" ] || [ "$YUM_ACTION" == "upgrade-to" ] \
@@ -203,7 +208,7 @@ tar c /var/lib/rpm /etc/yum.repos.d /etc/yum.conf /etc/dnf/dnf.conf 2>/dev/null 
 
 qvm-run $QVMRUN_OPTS --pass-io $UPDATEVM "script --quiet --return --command '/usr/lib/qubes/qubes-download-dom0-updates.sh --doit --nogui $(escape_args "${ALL_OPTS[@]}")' /dev/null" < /dev/null
 RETCODE=$?
-if [ "$CHECK_ONLY" == "1" ]; then
+if [ "$REMOTE_ONLY" == "1" ]; then
     exit $RETCODE
 elif [ "$RETCODE" -ne 0 ]; then
     exit $RETCODE

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -206,7 +206,15 @@ qvm-run --nogui -q $UPDATEVM 'rm -rf /var/lib/qubes/dom0-updates/etc' || exit 1
 tar c /var/lib/rpm /etc/yum.repos.d /etc/yum.conf /etc/dnf/dnf.conf 2>/dev/null | \
    qvm-run --nogui -q --pass-io "$UPDATEVM" 'LC_MESSAGES=C tar x -C /var/lib/qubes/dom0-updates 2>&1 | grep -v -E "s in the future"'
 
-qvm-run $QVMRUN_OPTS --pass-io $UPDATEVM "script --quiet --return --command '/usr/lib/qubes/qubes-download-dom0-updates.sh --doit --nogui $(escape_args "${ALL_OPTS[@]}")' /dev/null" < /dev/null
+CMD="/usr/lib/qubes/qubes-download-dom0-updates.sh --doit --nogui $(escape_args "${ALL_OPTS[@]}")"
+# Use 'script' to fake a terminal, so that we are shown sync and download
+# progress indicators. However, do it only if we are running in terminal
+# ourselves.
+if [ -t 1 ] && [ -t 2 ]; then
+    CMD="script --quiet --return --command '$CMD' /dev/null"
+fi
+
+qvm-run $QVMRUN_OPTS --pass-io $UPDATEVM "$CMD" < /dev/null
 RETCODE=$?
 if [ "$REMOTE_ONLY" == "1" ]; then
     exit $RETCODE


### PR DESCRIPTION
The actions are already supported at the remote end
(qubes-download-dom0-updates.sh).

This is in order to implement Salt functions for dom0, see
QubesOS/qubes-issues#5252.