### PR TITLE
Fix kernel install script clobbering kernel params ending in default=

### DIFF
--- a/system-config/kernel-xen-efi.install
+++ b/system-config/kernel-xen-efi.install
@@ -73,7 +73,7 @@ case "$COMMAND" in
               }' $EFI_DIR/xen.cfg >> $EFI_DIR/xen.cfg
             
             # then change the default
-            sed -e "s/default=.*/default=$KVER/" -i $EFI_DIR/xen.cfg
+            sed -e "s/^default=.*/default=$KVER/" -i $EFI_DIR/xen.cfg
         fi
 
         cp "/boot/vmlinuz-$KVER" "$EFI_DIR/"


### PR DESCRIPTION
The original `sed` arguments caused the replacing of kernel parameters, for example, the default sleep mode parameter, `mem_sleep_default` would have it's value replaced with the kernel version being installed.

The solution is to only match the start of lines, as proposed by @marmarek 

Fixes QubesOS/qubes-issues#5716