### PR TITLE
qfile-dom0-unpacker: support waiting for free space

### DIFF
--- a/dom0-updates/qfile-dom0-unpacker.c
+++ b/dom0-updates/qfile-dom0-unpacker.c
@@ -21,77 +21,77 @@
 
 int prepare_creds_return_uid(const char *username)
 {
-	struct passwd *pwd;
-	// First try name
-	pwd = getpwnam(username);
-	if (!pwd) {
-		// Then try UID
-		pwd = getpwuid(atoi(username));
-		if (!pwd) {
-			perror("getpwuid");
-			exit(1);
-		}
-	}
-	setenv("HOME", pwd->pw_dir, 1);
-	setenv("USER", pwd->pw_name, 1);
-	if (setgid(pwd->pw_gid) < 0) {
-		perror("setgid");
-		exit(1);
-	}
-	initgroups(pwd->pw_name, pwd->pw_gid);
-	if (setfsuid(pwd->pw_uid) < 0) {
-		perror("setfsuid");
-		exit(1);
-	}
-	return pwd->pw_uid;
+    struct passwd *pwd;
+    // First try name
+    pwd = getpwnam(username);
+    if (!pwd) {
+        // Then try UID
+        pwd = getpwuid(atoi(username));
+        if (!pwd) {
+            perror("getpwuid");
+            exit(1);
+        }
+    }
+    setenv("HOME", pwd->pw_dir, 1);
+    setenv("USER", pwd->pw_name, 1);
+    if (setgid(pwd->pw_gid) < 0) {
+        perror("setgid");
+        exit(1);
+    }
+    initgroups(pwd->pw_name, pwd->pw_gid);
+    if (setfsuid(pwd->pw_uid) < 0) {
+        perror("setfsuid");
+        exit(1);
+    }
+    return pwd->pw_uid;
 }
 
 int main(int argc, char ** argv)
 {
-	const char *incoming_dir;
-	int uid;
+    const char *incoming_dir;
+    int uid;
     int i;
-	char *var;
-	long long files_limit = DEFAULT_MAX_UPDATES_FILES;
-	long long bytes_limit = DEFAULT_MAX_UPDATES_BYTES;
+    char *var;
+    long long files_limit = DEFAULT_MAX_UPDATES_FILES;
+    long long bytes_limit = DEFAULT_MAX_UPDATES_BYTES;
 
-	struct statvfs st;
-	long long root_free_space;
+    struct statvfs st;
+    long long root_free_space;
 
-	if (argc < 3) {
-		fprintf(stderr, "Invalid parameters, usage: %s user dir [-v]\n", argv[0]);
-		exit(1);
-	}
+    if (argc < 3) {
+        fprintf(stderr, "Invalid parameters, usage: %s user dir [-v]\n", argv[0]);
+        exit(1);
+    }
 
-	uid = prepare_creds_return_uid(argv[1]);
+    uid = prepare_creds_return_uid(argv[1]);
 
-	incoming_dir = argv[2];
-	mkdir(incoming_dir, 0700);
-	if (chdir(incoming_dir)) {
-		fprintf(stderr, "Error chdir to %s\n", incoming_dir);
-		exit(1);
-	}
-	if (chroot(incoming_dir)) {//impossible
-		fprintf(stderr, "Error chroot to %s\n", incoming_dir);
-		exit(1);
-	}
-	if (setuid(uid) < 0) {
-		perror("setuid");
-		exit(1);
-	}
+    incoming_dir = argv[2];
+    mkdir(incoming_dir, 0700);
+    if (chdir(incoming_dir)) {
+        fprintf(stderr, "Error chdir to %s\n", incoming_dir);
+        exit(1);
+    }
+    if (chroot(incoming_dir)) {//impossible
+        fprintf(stderr, "Error chroot to %s\n", incoming_dir);
+        exit(1);
+    }
+    if (setuid(uid) < 0) {
+        perror("setuid");
+        exit(1);
+    }
 
-	statvfs(incoming_dir, &st);
-	// take a little margin with 90% of the free space
-	root_free_space = max(0, st.f_bfree * st.f_bsize * 0.90);
+    statvfs(incoming_dir, &st);
+    // take a little margin with 90% of the free space
+    root_free_space = max(0, st.f_bfree * st.f_bsize * 0.90);
 
-	bytes_limit = min(root_free_space, DEFAULT_MAX_UPDATES_BYTES);
+    bytes_limit = min(root_free_space, DEFAULT_MAX_UPDATES_BYTES);
 
-	if ((var=getenv("UPDATES_MAX_BYTES")))
-		bytes_limit = atoll(var);
-	if ((var=getenv("UPDATES_MAX_FILES")))
-		files_limit = atoll(var);
+    if ((var=getenv("UPDATES_MAX_BYTES")))
+        bytes_limit = atoll(var);
+    if ((var=getenv("UPDATES_MAX_FILES")))
+        files_limit = atoll(var);
 
-	set_size_limit(bytes_limit, files_limit);
+    set_size_limit(bytes_limit, files_limit);
     for (i = 3; i < argc; i++) {
         if (strcmp(argv[i], "-v") == 0) {
             set_verbose(1);
@@ -116,5 +116,5 @@ int main(int argc, char ** argv)
             exit(1);
         }
     }
-	return do_unpack();
+    return do_unpack();
 }


### PR DESCRIPTION
Add support for -w option, which makes the extract process to wait for
enough free space in the target directory. This is especially useful
when restoring a backup, which is multi-stage asynchronous process -
wait for another process to process extracted files (and free the space)
before extracting more.

QubesOS/qubes-issues#5478