### PR TITLE
Run commands locally if not showing remote output

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -109,17 +109,18 @@ elif [[ -z "${DISPLAY-}" ]]; then
     CONSOLE=1
 fi
 
-: "${YUM_ACTION=upgrade}"
-
-REMOTE_ONLY=
-if [ "$CHECK_ONLY" == "1" ] || [ "$YUM_ACTION" == "list" ] || [ "$YUM_ACTION" == "search" ]; then
-    REMOTE_ONLY=1
-fi
+REMOTE_ONLY=false may_clobber_template=false exit_cmd='&& exit'
+case ${YUM_ACTION=upgrade} in
+(reinstall|upgrade|upgrade-to|downgrade) may_clobber_template=true;;
+(list|search)
+    REMOTE_ONLY=true exit_cmd=
+    if [[ "$CONSOLE" = 1 ]]; then SHOW_OUTPUT=1; fi
+    ;;
+esac
 
 # Prevent implicit update of template - this would override user changes -
 # but do allow explicit template upgrade, downgrade, reinstall
-if [ "$YUM_ACTION" == "reinstall" ] || [ "$YUM_ACTION" == "upgrade" ] || [ "$YUM_ACTION" == "upgrade-to" ] \
-|| [ "$YUM_ACTION" == "downgrade" ] && find_regex_in_args '^qubes-template-' "${PKGS[@]}"; then
+if "$may_clobber_template" && find_regex_in_args '^qubes-template-' "${PKGS[@]}"; then
     TEMPLATE_EXCLUDE_OPTS=()
     echo "WARNING: Replacing a template will erase all files in template's /home and /rw !"
 
@@ -257,7 +258,13 @@ if [[ "$CONSOLE" = 1 ]]; then
 elif [[ "$GUI" = 1 ]] || [[ -t 1 ]] || [[ -t 2 ]]; then
     # In GUI mode, or in a terminal without --console, spawn an xterm to display
     # the output of the remote command.
-    CMD="xterm -e $CMD"
+    CMD="xterm -e /bin/sh -c '"'if "$@" '"$exit_cmd"'; then
+    status=0 prompt=succeeded
+else
+    status=$? prompt="failed with code $?"
+fi
+read -p "Fetching updates $prompt; press Enter to exit" q
+exit "$status"'"' sh $CMD"
 else
     QVMRUN_OPTS=(--nogui)
 fi
@@ -265,7 +272,7 @@ fi
 qvm-run "${QVMRUN_OPTS[@]}" -- "$UPDATEVM" "$CMD" < /dev/null
 
 RETCODE=$?
-if [ "$REMOTE_ONLY" == "1" ] || [ "$RETCODE" -ne 0 ]; then
+if "$REMOTE_ONLY" || [ "$RETCODE" -ne 0 ]; then
     exit $RETCODE
 fi
 # Wait for download completed

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -252,7 +252,11 @@ if [[ "$CONSOLE" = 1 ]]; then
             # progress output.  Since stdout and stderr are both terminals, qvm-run
             # will automatically sanitize them, but we explicitly tell it to anyway
             # as a precaution.
-            CMD="exec script --quiet --return --command '${CMD//\'/\'\\\'\'}'"
+            #
+            # We MUST NOT use ‘exec script’ here.  That causes ‘script’ to
+            # inherit the child processes of the shell.  ‘script’ mishandles
+            # this and enters an infinite loop.
+            CMD="script --quiet --return --command '${CMD//\'/\'\\\'\'}'"
         fi
     fi
 elif [[ "$GUI" = 1 ]] || [[ -t 1 ]] || [[ -t 2 ]]; then

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -109,18 +109,18 @@ elif [[ -z "${DISPLAY-}" ]]; then
     CONSOLE=1
 fi
 
-REMOTE_ONLY=false may_clobber_template=false exit_cmd='&& exit'
+REMOTE_ONLY= may_clobber_template=0 exit_cmd='&& exit'
 case ${YUM_ACTION=upgrade} in
-(reinstall|upgrade|upgrade-to|downgrade) may_clobber_template=true;;
+(reinstall|erase|remove|upgrade|upgrade-to|downgrade) may_clobber_template=1;;
 (list|search)
-    REMOTE_ONLY=true exit_cmd=
+    REMOTE_ONLY=1 exit_cmd=
     if [[ "$CONSOLE" = 1 ]]; then SHOW_OUTPUT=1; fi
     ;;
 esac
 
 # Prevent implicit update of template - this would override user changes -
 # but do allow explicit template upgrade, downgrade, reinstall
-if "$may_clobber_template" && find_regex_in_args '^qubes-template-' "${PKGS[@]}"; then
+if [[ "$may_clobber_template" = '1' ]] && find_regex_in_args '^qubes-template-' "${PKGS[@]}"; then
     TEMPLATE_EXCLUDE_OPTS=()
     echo "WARNING: Replacing a template will erase all files in template's /home and /rw !"
 
@@ -272,7 +272,7 @@ fi
 qvm-run "${QVMRUN_OPTS[@]}" -- "$UPDATEVM" "$CMD" < /dev/null
 
 RETCODE=$?
-if "$REMOTE_ONLY" || [ "$RETCODE" -ne 0 ]; then
+if [[ "$REMOTE_ONLY" = '1' ]] || [ "$RETCODE" -ne 0 ]; then
     exit $RETCODE
 fi
 # Wait for download completed

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -47,7 +47,6 @@ YUM_OPTS=()
 GUI=
 CHECK_ONLY=
 ALL_OPTS=( "${@}" )
-QVMRUN_OPTS=()
 SHOW_OUTPUT=0
 CONSOLE=0
 CLEAN=
@@ -241,7 +240,7 @@ CMD="/usr/lib/qubes/qubes-download-dom0-updates.sh --doit --nogui"
 # by the following is.
 for i in "${ALL_OPTS[@]}"; do CMD+=" '${i//\'/\'\\\'\'}'"; done
 
-QVMRUN_OPTS=(--filter-escape-chars)
+QVMRUN_OPTS=(--quiet --filter-escape-chars)
 # If we are running in a terminal, run the command in its own terminal in the UpdateVM.
 if [[ "$CONSOLE" = 1 ]]; then
     QVMRUN_OPTS+=(--nogui)


### PR DESCRIPTION
Salt parses the stdout of the command.  Therefore, if we are not showing
the remote command’s stdout, we need to run the command locally too.