### PR TITLE
dom0-update: do not send --downloadonly option to the updatevm

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -63,6 +63,10 @@ while [ $# -gt 0 ]; do
             UPDATEVM_OPTS+=( "$1" )
             QVMTEMPLATE_OPTS+=( "$1" )
             ;;
+        --downloadonly)
+            YUM_OPTS+=( "${1}" )
+            QVMTEMPLATE_OPTS+=( "$1" )
+            ;;
         --clean)
             CLEAN=1
             UPDATEVM_OPTS+=( "$1" )


### PR DESCRIPTION
The updatevm already downloads packages only (either using
--downloadonly option internally, or using yumdownloader). The option
from the user matters for the dnf call in dom0 only.

Especially, sending --downloadonly breaks downloading updates via
debian-10, which uses yumdownloader, as it doesn't have --downloadonly
option.

This is mostly relevant for R4.0 -> R4.1 upgrade (and maybe some future
too?), as the process uses --downloadonly option internally.

QubesOS/qubes-issues#5685