### PR TITLE
Fix dom0 updates if `repo_gpgcheck=1` is globally set

### DIFF
--- a/dom0-updates/qubes-cached.repo
+++ b/dom0-updates/qubes-cached.repo
@@ -1,6 +1,6 @@
 [qubes-dom0-cached]
 name = Qubes OS Repository for Dom0
 baseurl = file:///var/lib/qubes/updates
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-1-primary
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4-primary
 gpgcheck = 1
 metadata_expire = 0

--- a/dom0-updates/qubes-cached.repo
+++ b/dom0-updates/qubes-cached.repo
@@ -3,4 +3,5 @@ name = Qubes OS Repository for Dom0
 baseurl = file:///var/lib/qubes/updates
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4-primary
 gpgcheck = 1
+repo_gpgcheck = 0
 metadata_expire = 0


### PR DESCRIPTION
If `repo_gpgcheck=1` is set globally in dom0, updates break.  They will also break if DNF gets fixed to check signatures against the specific OpenPGP key specified in the repository file, instead of against the RPM keyring.  This fixes both problems.