### PR TITLE
Make qubes.repo.* services handle new template repos location

### DIFF
--- a/qubes-rpc/qubes.repos.Disable
+++ b/qubes-rpc/qubes.repos.Disable
@@ -11,6 +11,8 @@ os.umask(0o022)
 
 base = dnf.Base()
 
+base.conf.reposdir.append('/etc/qubes/repo-templates')
+
 base.read_all_repos()
 
 reponame = sys.argv[1]

--- a/qubes-rpc/qubes.repos.Enable
+++ b/qubes-rpc/qubes.repos.Enable
@@ -11,6 +11,8 @@ os.umask(0o022)
 
 base = dnf.Base()
 
+base.conf.reposdir.append('/etc/qubes/repo-templates')
+
 base.read_all_repos()
 
 reponame = sys.argv[1]

--- a/qubes-rpc/qubes.repos.List
+++ b/qubes-rpc/qubes.repos.List
@@ -7,6 +7,8 @@ import dnf
 
 base = dnf.Base()
 
+base.conf.reposdir.append('/etc/qubes/repo-templates')
+
 base.read_all_repos()
 
 first = True


### PR DESCRIPTION
Template repositories are now defined in /etc/qubes/repo-templates -
handle this location too.

QubesOS/qubes-issues#7252