### PR TITLE
Minor improvements to qubes-dom0-update

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -365,8 +365,7 @@ fi
 
 if [[ "$REBOOT_REQUIRED" = 1 ]]; then
     echo "This upgrade requires system restart before doing anything else."
-    echo -n "Do you want to restart now? [Y/n] "
-    read answer
+    read -p 'Do you want to restart now? [Y/n] ' answer || :
     if [[ "$answer" != "n" ]] && [[ "$answer" != "N" ]]; then
         reboot
     fi

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -1,5 +1,6 @@
 #!/bin/bash --
 set -o pipefail
+unset YUM_ACTION UPDATEVM
 
 check_template_in_args () {
     local pkg

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -1,5 +1,5 @@
 #!/bin/bash --
-set -o pipefail
+set -euo pipefail
 unset YUM_ACTION UPDATEVM
 
 check_template_in_args () {

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash --
 
 find_regex_in_args() {
     local regex="${1}"

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -219,15 +219,15 @@ echo "Using $UPDATEVM as UpdateVM to download updates for Dom0; this may take so
 
 # qvm-run by default auto-starts the VM if not running
 readonly dom0_updates_dir=/var/lib/qubes/dom0-updates
-qvm-run --nogui -q -u root -- "$UPDATEVM" "mkdir -m 775 -p -- '$dom0_updates_dir'" || exit 1
-qvm-run --nogui -q -u root -- "$UPDATEVM" "chown -R -- user:user '$dom0_updates_dir'" || exit 1
-qvm-run --nogui -q -- "$UPDATEVM" "rm -rf -- '$dom0_updates_dir/etc' '$dom0_updates_dir/var/lib/rpm'" || exit 1
+qvm-run --no-gui -q -u root -- "$UPDATEVM" "mkdir -m 775 -p -- '$dom0_updates_dir'" || exit 1
+qvm-run --no-gui -q -u root -- "$UPDATEVM" "chown -R -- user:user '$dom0_updates_dir'" || exit 1
+qvm-run --no-gui -q -- "$UPDATEVM" "rm -rf -- '$dom0_updates_dir/etc' '$dom0_updates_dir/var/lib/rpm'" || exit 1
 dnf_conf=(/var/lib/rpm /etc/yum.repos.d /etc/dnf/dnf.conf /etc/pki/rpm-gpg/RPM-GPG-KEY-*)
 if [[ -d /etc/yum/vars ]]; then
     dnf_conf+=(/etc/yum/vars)
 fi
 (cd / && exec tar -c -- "${dnf_conf[@]#/}") |
-   qvm-run --nogui -q --pass-io -- "$UPDATEVM" "LC_MESSAGES=C tar -C '$dom0_updates_dir' -x &&
+   qvm-run --no-gui -q --pass-io -- "$UPDATEVM" "LC_MESSAGES=C tar -C '$dom0_updates_dir' -x &&
    sed -Ei 's,^([[:space:]]*gpgkey[[:space:]]*=[[:space:]]*file://)(/etc/pki/rpm-gpg/RPM-GPG-KEY-),\\1$dom0_updates_dir\\2,' '$dom0_updates_dir/etc/yum.repos.d'/*.repo" >/dev/null 2>&1 || {
    status=$?
    echo "Sending repository information to UpdateVM failed: code $status">&2
@@ -244,7 +244,7 @@ for i in "${UPDATEVM_OPTS[@]}"; do CMD+=" '${i//\'/\'\\\'\'}'"; done
 QVMRUN_OPTS=(--quiet --filter-escape-chars)
 # If we are running in a terminal, run the command in its own terminal in the UpdateVM.
 if [[ "$CONSOLE" = 1 ]]; then
-    QVMRUN_OPTS+=(--nogui)
+    QVMRUN_OPTS+=(--no-gui)
     if [[ "$SHOW_OUTPUT" = 1 ]]; then
         QVMRUN_OPTS+=(--pass-io)
         if [[ -t 1 ]] && [[ -t 2 ]]; then
@@ -270,7 +270,7 @@ fi
 read -p "Fetching updates $prompt; press Enter to exit" q
 exit "$status"'"' sh $CMD"
 else
-    QVMRUN_OPTS=(--nogui)
+    QVMRUN_OPTS=(--no-gui)
 fi
 
 qvm-run "${QVMRUN_OPTS[@]}" -- "$UPDATEVM" "$CMD" < /dev/null

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -234,47 +234,50 @@ fi
    exit "$status"
 }
 
-CMD="/usr/lib/qubes/qubes-download-dom0-updates.sh --doit --nogui"
+declare -a QVMRUN_OPTS CMD_ARRAY
+CMD_ARRAY=(/usr/lib/qubes/qubes-download-dom0-updates.sh --doit --nogui)
 
-# We avoid using bash’s own facilities for this, as they produce $'\n'-style
-# strings in certain cases.  These are not portable, whereas the string produced
-# by the following is.
-for i in "${UPDATEVM_OPTS[@]}"; do CMD+=" '${i//\'/\'\\\'\'}'"; done
-
-QVMRUN_OPTS=(--quiet --filter-escape-chars)
+QVMRUN_OPTS=(--quiet --filter-escape-chars --no-shell)
 # If we are running in a terminal, run the command in its own terminal in the UpdateVM.
 if [[ "$CONSOLE" = 1 ]]; then
     QVMRUN_OPTS+=(--no-gui)
     if [[ "$SHOW_OUTPUT" = 1 ]]; then
         QVMRUN_OPTS+=(--pass-io)
         if [[ -t 1 ]] && [[ -t 2 ]]; then
+            CMD='/usr/lib/qubes/qubes-download-dom0-updates.sh --doit --nogui'
+
+            # We avoid using bash’s own facilities for this, as they produce $'\n'-style
+            # strings in certain cases.  These are not portable, whereas the string produced
+            # by the following is.
+            for i in "${UPDATEVM_OPTS[@]}"; do CMD+=" '${i//\'/\'\\\'\'}'"; done
+
             # Use ‘script’ to emulate a TTY, so that we get status bars and other
             # progress output.  Since stdout and stderr are both terminals, qvm-run
             # will automatically sanitize them, but we explicitly tell it to anyway
             # as a precaution.
             #
-            # We MUST NOT use ‘exec script’ here.  That causes ‘script’ to
+            # We MUST NOT use ‘exec’ here.  That causes ‘script’ to
             # inherit the child processes of the shell.  ‘script’ mishandles
             # this and enters an infinite loop.
-            CMD="script --quiet --return --command '${CMD//\'/\'\\\'\'}'"
+            CMD_ARRAY=(script --quiet --return --command "$CMD")
         fi
     fi
 elif [[ "$GUI" = 1 ]] || [[ -t 1 ]] || [[ -t 2 ]]; then
     # In GUI mode, or in a terminal without --console, spawn an xterm to display
     # the output of the remote command.
-    CMD="xterm -e /bin/sh -c '"'if "$@" '"$exit_cmd"'; then
+    CMD_ARRAY=(xterm -e /bin/sh -c 'if "$@" '"$exit_cmd"'; then
     status=0 prompt=succeeded
 else
     status=$? prompt="failed with code $?"
 fi
 read -p "Fetching updates $prompt; press Enter to exit" q
-exit "$status"'"' sh $CMD"
+exit "$status"' sh "${CMD_ARRAY[@]}")
 else
-    QVMRUN_OPTS=(--no-gui)
+    QVMRUN_OPTS=(--no-gui --no-shell)
 fi
 
 RETCODE=0
-qvm-run "${QVMRUN_OPTS[@]}" -- "$UPDATEVM" "$CMD" < /dev/null || RETCODE=$?
+qvm-run "${QVMRUN_OPTS[@]}" -- "$UPDATEVM" "${CMD_ARRAY[@]}" < /dev/null || RETCODE=$?
 if [[ "$REMOTE_ONLY" = '1' ]] || [[ "$RETCODE" -ne 0 ]]; then
     if [[ "$CHECK_ONLY" = '1' ]]; then
         if [[ "$RETCODE" -eq 100 ]]; then

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -221,7 +221,11 @@ readonly dom0_updates_dir=/var/lib/qubes/dom0-updates
 qvm-run --nogui -q -u root -- "$UPDATEVM" "mkdir -m 775 -p -- '$dom0_updates_dir'" || exit 1
 qvm-run --nogui -q -u root -- "$UPDATEVM" "chown -R -- user:user '$dom0_updates_dir'" || exit 1
 qvm-run --nogui -q -- "$UPDATEVM" "rm -rf -- '$dom0_updates_dir/etc' '$dom0_updates_dir/var/lib/rpm'" || exit 1
-(cd / && exec tar -c -- var/lib/rpm etc/yum/vars etc/yum.repos.d etc/yum.conf etc/dnf/dnf.conf etc/pki/rpm-gpg/RPM-GPG-KEY-* 2>/dev/null) |
+dnf_conf=(/var/lib/rpm /etc/yum.repos.d /etc/dnf/dnf.conf /etc/pki/rpm-gpg/RPM-GPG-KEY-*)
+if [[ -d /etc/yum/vars ]]; then
+    dnf_conf+=(/etc/yum/vars)
+fi
+(cd / && exec tar -c -- "${dnf_conf[@]#/}") |
    qvm-run --nogui -q --pass-io -- "$UPDATEVM" "LC_MESSAGES=C tar -C '$dom0_updates_dir' -x &&
    sed -Ei 's,^([[:space:]]*gpgkey[[:space:]]*=[[:space:]]*file://)(/etc/pki/rpm-gpg/RPM-GPG-KEY-),\\1$dom0_updates_dir\\2,' '$dom0_updates_dir/etc/yum.repos.d'/*.repo" >/dev/null 2>&1 || {
    status=$?

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -104,7 +104,7 @@ while [[ $# -gt 0 ]]; do
             fi
             ;;
         -*)
-            YUM_OPTS+=( "${1}" )
+            YUM_OPTS+=( "$1" )
             UPDATEVM_OPTS+=( "$1" )
             QVMTEMPLATE_OPTS+=( "$1" )
             ;;
@@ -289,7 +289,7 @@ if [[ "$REMOTE_ONLY" = '1' ]] || [[ "$RETCODE" -ne 0 ]]; then
             echo "Failed to check for dom0 updates" >&2
         fi
     fi
-    exit $RETCODE
+    exit "$RETCODE"
 fi
 # Wait for download completed
 while pidof -x qubes-receive-updates >/dev/null; do sleep 0.5; done
@@ -336,9 +336,7 @@ if [[ -f /var/lib/qubes/updates/repodata/repomd.xml ]]; then
 fi
 
 if [[ "${#PKGS[@]}" -gt 0 ]]; then
-
-    dnf "${YUM_OPTS[@]}" $YUM_ACTION "${PKGS[@]}" ; RETCODE=$?
-
+    dnf "${YUM_OPTS[@]}" $YUM_ACTION "${PKGS[@]}"
 elif [[ -f /var/lib/qubes/updates/repodata/repomd.xml ]]; then
     # Above file exists only when at least one package was downloaded
     if [[ "$GUI" == "1" ]]; then

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -11,12 +11,12 @@ check_template_in_args () {
 
 UPDATEVM="$(qubes-prefs --force-root updatevm)"
 
-if [ -z "$UPDATEVM" ]; then
+if [[ -z "$UPDATEVM" ]]; then
     echo "UpdateVM not set, exiting"
     exit 1
 fi
 
-if [ "$1" = "--help" ]; then
+if [[ "$1" = "--help" ]]; then
     echo "This tool is used to download packages for dom0. Without package list"
     echo "it checks for updates for installed packages"
     echo ""
@@ -54,7 +54,7 @@ TEMPLATE_BACKUP=
 FORCE_XEN_UPGRADE=
 REBOOT_REQUIRED=
 # Filter out some dnf options and collect packages list
-while [ $# -gt 0 ]; do
+while [[ $# -gt 0 ]]; do
     case "$1" in
         --enablerepo=*|\
         --disablerepo=*)
@@ -133,7 +133,7 @@ case ${YUM_ACTION=upgrade} in
     ;;
 esac
 
-if [ "$CHECK_ONLY" == "1" ]; then
+if [[ "$CHECK_ONLY" == "1" ]]; then
     REMOTE_ONLY=1
     CONSOLE=1
 fi
@@ -157,20 +157,20 @@ YUM_OPTS=( "${TEMPLATE_EXCLUDE_OPTS[@]}" "${YUM_OPTS[@]}" )
 UPDATEVM_OPTS=( "${TEMPLATE_EXCLUDE_OPTS[@]}" "${UPDATEVM_OPTS[@]}" )
 
 ID=$(id -ur)
-if [ "$ID" != 0 ] && [ -z "$GUI" ] && [ -z "$CHECK_ONLY" ] ; then
+if [[ "$ID" != 0 ]] && [[ -z "$GUI" ]] && [[ -z "$CHECK_ONLY" ]] ; then
     echo "This script should be run as root (when used in console mode), use sudo." >&2
     exit 1
 fi
 
-if [ "$GUI" == "1" ] && [ ${#PKGS[@]} -ne 0 ]; then
+if [[ "$GUI" == "1" ]] && [[ ${#PKGS[@]} -ne 0 ]]; then
     echo "ERROR: GUI mode can be used only for updates" >&2
     exit 1
 fi
 
-if [ "$GUI" == "1" ]; then
+if [[ "$GUI" == "1" ]]; then
     apps="xterm konsole yumex apper gpk-update-viewer"
 
-    if [ -n "$KDE_FULL_SESSION" ]; then
+    if [[ -n "${KDE_FULL_SESSION-}" ]]; then
         apps="konsole xterm apper yumex gpk-update-viewer"
     fi
 
@@ -188,11 +188,11 @@ if [ "$GUI" == "1" ]; then
         fi
     done
 
-    if [ -z "$guiapp" ]; then
+    if [[ -z "$guiapp" ]]; then
         message1="You don't have any supported dnf frontend installed."
         message2="Install (using qubes-dom0-update) one of: $apps"
 
-        if [ "$KDE_FULL_SESSION" ]; then
+        if [[ -n "${KDE_FULL_SESSION-}" ]]; then
             kdialog --sorry "$message1<br/>$message2"
         else
             zenity --error --text "$message1\n$message2"
@@ -203,12 +203,12 @@ if [ "$GUI" == "1" ]; then
 fi
 
 # Do not start VM automatically when running from cron (only checking for updates)
-if [ "$CHECK_ONLY" == "1" ] && ! qvm-check -q --running "$UPDATEVM" > /dev/null 2>&1; then
+if [[ "$CHECK_ONLY" = "1" ]] && ! qvm-check -q --running -- "$UPDATEVM" > /dev/null 2>&1; then
     echo "ERROR: UpdateVM not running, not starting it in non-interactive mode" >&2
     exit 1
 fi
 
-if [ -n "$CLEAN" ]; then
+if [[ -n "$CLEAN" ]]; then
     rm -f /var/lib/qubes/updates/rpm/*
     rm -f /var/lib/qubes/updates/repodata/*
 fi
@@ -271,11 +271,11 @@ fi
 qvm-run "${QVMRUN_OPTS[@]}" -- "$UPDATEVM" "$CMD" < /dev/null
 
 RETCODE=$?
-if [[ "$REMOTE_ONLY" = '1' ]] || [ "$RETCODE" -ne 0 ]; then
-    if [ "$CHECK_ONLY" = '1' ]; then
-        if [ "$RETCODE" -eq 100 ]; then
+if [[ "$REMOTE_ONLY" = '1' ]] || [[ "$RETCODE" -ne 0 ]]; then
+    if [[ "$CHECK_ONLY" = '1' ]]; then
+        if [[ "$RETCODE" -eq 100 ]]; then
             echo "There are dom0 updates available" >&2
-        elif [ "$RETCODE" -eq 0 ]; then
+        elif [[ "$RETCODE" -eq 0 ]]; then
             echo "No dom0 updates available" >&2
         else
             echo "Failed to check for dom0 updates" >&2
@@ -286,7 +286,7 @@ fi
 # Wait for download completed
 while pidof -x qubes-receive-updates >/dev/null; do sleep 0.5; done
 
-if [ -r /var/lib/qubes/updates/errors ]; then
+if [[ -r /var/lib/qubes/updates/errors ]]; then
     echo "*** ERROR while receiving updates:" >&2
     cat /var/lib/qubes/updates/errors >&2
     echo "--> if you want to use packages that were downloaded correctly, use dnf directly now" >&2
@@ -295,7 +295,7 @@ if [ -r /var/lib/qubes/updates/errors ]; then
 fi
 
 # Check for major xen upgrade and warn the user
-if [ -f /var/lib/qubes/updates/repodata/repomd.xml ]; then
+if [[ -f /var/lib/qubes/updates/repodata/repomd.xml ]]; then
     xen_in_update=$(ls /var/lib/qubes/updates/rpm/xen-libs-[1-9]* 2>/dev/null \
         |sed -e 's/.*xen-libs-//' \
         |cut -f 1,2 -d . \
@@ -303,19 +303,19 @@ if [ -f /var/lib/qubes/updates/repodata/repomd.xml ]; then
     xen_running=$(xl info xen_version|cut -f 1,2 -d .)
     # cut off -rc if any
     xen_running=${xen_running%-*}
-    if [ -n "$xen_in_update" ] && [ "$xen_in_update" != "$xen_running" ]; then
+    if [[ -n "$xen_in_update" ]] && [[ "$xen_in_update" != "$xen_running" ]]; then
         # check if there are running VMs
-        if [ "$(xl list|wc -l)" -gt 2 ]; then
+        if [[ "$(xl list|wc -l)" -gt 2 ]]; then
             echo "WARNING: Attempting a major Xen upgrade ($xen_running -> $xen_in_update) while some qubes are running"
             echo "WARNING: You will not be able to interact with them (not even cleanly shutdown) until you restart the system"
             echo "List of running qubes:"
             qvm-ls --running | grep -v dom0
-            if [ "$FORCE_XEN_UPGRADE" = 1 ]; then
+            if [[ "$FORCE_XEN_UPGRADE" = 1 ]]; then
                 echo "Continuing as requested"
             else
                 echo -n "Do you want to shutdown all the qubes now? [y/N] "
                 read answer
-                if [ "$answer" = "y" ] || [ "$answer" = "Y" ]; then
+                if [[ "$answer" = "y" ]] || [[ "$answer" = "Y" ]]; then
                     qvm-shutdown --all --wait
                 else
                     echo "Please shutdown all the qubes, then resume the update with 'sudo dnf upgrade'"
@@ -327,19 +327,19 @@ if [ -f /var/lib/qubes/updates/repodata/repomd.xml ]; then
     fi
 fi
 
-if [ ${#PKGS[@]} -gt 0 ]; then
+if [[ "${#PKGS[@]}" -gt 0 ]]; then
 
     dnf "${YUM_OPTS[@]}" $YUM_ACTION "${PKGS[@]}" ; RETCODE=$?
 
-elif [ -f /var/lib/qubes/updates/repodata/repomd.xml ]; then
+elif [[ -f /var/lib/qubes/updates/repodata/repomd.xml ]]; then
     # Above file exists only when at least one package was downloaded
-    if [ "$GUI" == "1" ]; then
+    if [[ "$GUI" == "1" ]]; then
         # refresh packagekit metadata, GUI utilities use it
         pkcon refresh force
         $guiapp
     else
         dnf check-update ||
-        if [ $? -eq 100 ]; then # Run dnf with options
+        if [[ $? -eq 100 ]]; then # Run dnf with options
             dnf "${YUM_OPTS[@]}" $YUM_ACTION; RETCODE=$?
         fi
     fi
@@ -353,16 +353,16 @@ else
         echo "*** WARNING: cannot set feature 'updates-available'" >&2
     fi
     echo "No updates available" >&2
-    if [ "$GUI" == "1" ]; then
+    if [[ "$GUI" == "1" ]]; then
         zenity --info --title='Dom0 updates' --text='No updates available'
     fi
 fi
 
-if [ "$REBOOT_REQUIRED" = 1 ]; then
+if [[ "$REBOOT_REQUIRED" = 1 ]]; then
     echo "This upgrade requires system restart before doing anything else."
     echo -n "Do you want to restart now? [Y/n] "
     read answer
-    if [ "$answer" != "n" ] && [ "$answer" != "N" ]; then
+    if [[ "$answer" != "n" ]] && [[ "$answer" != "N" ]]; then
         reboot
     fi
 fi

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -1,13 +1,9 @@
 #!/bin/bash --
 
-find_regex_in_args() {
-    local regex="${1}"
-    shift 1
-
-    for arg in "${@}"; do
-        if echo "${arg}" | grep -q -e "${regex}"; then
-            return 0
-        fi
+check_template_in_args () {
+    local pkg
+    for pkg; do
+        if [[ "$pkg" =~ ^qubes-template- ]]; then return 0; fi
     done
 
     return 1
@@ -143,7 +139,7 @@ if [ "$CHECK_ONLY" == "1" ]; then
 fi
 
 # Redirect operations on templates to qvm-template command
-if find_regex_in_args '^qubes-template-' "${PKGS[@]}"; then
+if check_template_in_args "${PKGS[@]}"; then
     if [[ ${#PKGS[@]} -ne 1 ]]; then
         echo "ERROR: Specify only one package to reinstall template"
         exit 2

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -273,9 +273,8 @@ else
     QVMRUN_OPTS=(--no-gui)
 fi
 
-qvm-run "${QVMRUN_OPTS[@]}" -- "$UPDATEVM" "$CMD" < /dev/null
-
-RETCODE=$?
+RETCODE=0
+qvm-run "${QVMRUN_OPTS[@]}" -- "$UPDATEVM" "$CMD" < /dev/null || RETCODE=$?
 if [[ "$REMOTE_ONLY" = '1' ]] || [[ "$RETCODE" -ne 0 ]]; then
     if [[ "$CHECK_ONLY" = '1' ]]; then
         if [[ "$RETCODE" -eq 100 ]]; then
@@ -343,10 +342,12 @@ elif [[ -f /var/lib/qubes/updates/repodata/repomd.xml ]]; then
         pkcon refresh force
         $guiapp
     else
-        dnf check-update ||
-        if [[ $? -eq 100 ]]; then # Run dnf with options
-            dnf "${YUM_OPTS[@]}" $YUM_ACTION; RETCODE=$?
-        fi
+        RETCODE=0
+        dnf check-update || {
+            if [[ $? -eq 100 ]]; then # Run dnf with options
+                dnf "${YUM_OPTS[@]}" $YUM_ACTION || RETCODE=$?
+            fi
+        }
     fi
     if dnf -q check-update; then
         if ! qvm-features dom0 updates-available '' 2>/dev/null; then

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -1,4 +1,5 @@
 #!/bin/bash --
+set -o pipefail
 
 check_template_in_args () {
     local pkg


### PR DESCRIPTION
This uses bash regex matching instead of the `echo | grep` anti-pattern,
replaces an `==` with `=`, adds a missing `--`, and unsets a variable
that will be checked for being set later.  It also replaces some uses of
`[` with `[[`.

The same approach used here could be used to refactor
qubes-gpg-client-wrapper if it were worth the time, which it probably
isn’t unless qubes-gpg-client-wrapper will see future use.