### PR TITLE
qubes-dom0-update: Pass --check-only option to the updatevm too

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -82,6 +82,7 @@ while [ $# -gt 0 ]; do
             ;;
         --check-only)
             CHECK_ONLY=1
+            UPDATEVM_OPTS+=( "$1" )
             ;;
         --preserve-terminal)
             exit_cmd=

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -275,6 +275,15 @@ qvm-run "${QVMRUN_OPTS[@]}" -- "$UPDATEVM" "$CMD" < /dev/null
 
 RETCODE=$?
 if [[ "$REMOTE_ONLY" = '1' ]] || [ "$RETCODE" -ne 0 ]; then
+    if [ "$CHECK_ONLY" = '1' ]; then
+        if [ "$RETCODE" -eq 100 ]; then
+            echo "There are dom0 updates available" >&2
+        elif [ "$RETCODE" -eq 0 ]; then
+            echo "No dom0 updates available" >&2
+        else
+            echo "Failed to check for dom0 updates" >&2
+        fi
+    fi
     exit $RETCODE
 fi
 # Wait for download completed

--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -137,6 +137,10 @@ case ${YUM_ACTION=upgrade} in
     ;;
 esac
 
+if [ "$CHECK_ONLY" == "1" ]; then
+    REMOTE_ONLY=1
+fi
+
 # Redirect operations on templates to qvm-template command
 if find_regex_in_args '^qubes-template-' "${PKGS[@]}"; then
     if [[ ${#PKGS[@]} -ne 1 ]]; then


### PR DESCRIPTION
The updatevm script does need this option too, for two reasons:
 - to skip downloading updates if only check was requested
 - to report updates availability via exit code

The second point is critical for setting 'updates-available' flag.

Fixs QubesOS/qubes-issues#7417