### PR TITLE
dom0-update: do not show xterm with update check process

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -26,7 +26,7 @@ if [ "$1" = "--help" ]; then
     echo ""
     echo "Usage: $0 [--clean] [--check-only] [--gui] [<pkg list>]"
     echo "    --clean      clean dnf cache before doing anything"
-    echo "    --check-only only check for updates (no install)"
+    echo "    --check-only only check for updates (no install); implies --console"
     echo "    --gui        use gpk-update-viewer for update selection, conflicts with --console"
     echo "    --action=... use specific dnf action, instead of automatic install/update"
     echo "    --force-xen-upgrade  force major Xen upgrade even if some qubes are running"
@@ -139,6 +139,7 @@ esac
 
 if [ "$CHECK_ONLY" == "1" ]; then
     REMOTE_ONLY=1
+    CONSOLE=1
 fi
 
 # Redirect operations on templates to qvm-template command


### PR DESCRIPTION
This may mess with exit code (critical for setting updates-available
flag), but also may be confusing when started from cron.

This is the last part of dom0 updates notification fix.

Fixes QubesOS/qubes-issues#7437