### PR TITLE
dracut: do not fail native (non-Xen) boot

### DIFF
--- a/dracut/modules.d/90qubes-pciback/qubes-pciback.sh
+++ b/dracut/modules.d/90qubes-pciback/qubes-pciback.sh
@@ -56,7 +56,13 @@ for dev in $HIDE_PCI; do
     echo -n "$BDF" > /sys/bus/pci/drivers/pciback/new_slot
     echo -n "$BDF" > /sys/bus/pci/drivers/pciback/bind
 done
-) || die 'Cannot unbind PCI devices.'
+) || {
+    if [ -r /sys/hypervisor/type ] && [ "$(cat /sys/hypervisor/type)" = "xen" ]; then
+        die 'Cannot unbind PCI devices.'
+    else
+        warn 'Cannot unbind PCI devices - not running under Xen'
+    fi
+}
 if [ "$usb_in_dom0" = true ]; then
     info "Restricting USB in dom0 via usbguard."
     systemctl --quiet -- enable usbguard.service

--- a/dracut/modules.d/90qubes-pciback/qubes-pciback.sh
+++ b/dracut/modules.d/90qubes-pciback/qubes-pciback.sh
@@ -57,7 +57,12 @@ for dev in $HIDE_PCI; do
     echo -n "$BDF" > /sys/bus/pci/drivers/pciback/bind
 done
 ) || {
-    if [ -r /sys/hypervisor/type ] && [ "$(cat /sys/hypervisor/type)" = "xen" ]; then
+    hypervisor_type=
+    if [ -r /sys/hypervisor/type ]; then
+        read -r hypervisor_type < /sys/hypervisor/type || \
+            die 'Cannot determine hypervisor type'
+    fi
+    if [ "$hypervisor_type" = "xen" ]; then
         die 'Cannot unbind PCI devices.'
     else
         warn 'Cannot unbind PCI devices - not running under Xen'


### PR DESCRIPTION
When booting Linux directly, binding devices to xen-pciback will fail.
Do not fail the boot in this case.

https://github.com/QubesOS/qubes-issues/issues/7390#issuecomment-1086745690