### PR TITLE
dracut: adjust 'bochs-drm' module name

### DIFF
--- a/dracut/modules.d/90extra-modules/module-setup.sh
+++ b/dracut/modules.d/90extra-modules/module-setup.sh
@@ -14,9 +14,9 @@ installkernel() {
             hostonly='' instmods cirrus
         fi
         if [ "$(cat /sys/bus/pci/devices/0000:00:02.0/vendor 2>/dev/null || :)" = "0x1234" ]; then
-            hostonly='' instmods bochs_drm
+            hostonly='' instmods bochs_drm bochs
         fi
     else
-        instmods cirrus bochs_drm
+        instmods cirrus bochs_drm bochs
     fi
 }


### PR DESCRIPTION
In Linux 5.15 it got renamed to 'bochs'. Adjust the dracut module to
include both - instmods will ignore non-existing one.