### PR TITLE
Improve wording for failures of qubes-dom0-update

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -294,6 +294,7 @@ if [ -r /var/lib/qubes/updates/errors ]; then
     echo "*** ERROR while receiving updates:" >&2
     cat /var/lib/qubes/updates/errors >&2
     echo "--> if you want to use packages that were downloaded correctly, use dnf directly now" >&2
+    echo "--> otherwise, you can use --clean to remove left-over packages" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Make it clear that you can use --clean to just start over.