### PR TITLE
qubes-pciback: add optional support for PCI device whitelisting

### DIFF
--- a/dracut/modules.d/90qubes-pciback/module-setup.sh
+++ b/dracut/modules.d/90qubes-pciback/module-setup.sh
@@ -10,6 +10,7 @@ install () {
     inst_multiple /etc/nsswitch.conf
     inst_multiple /etc/usbguard/{qubes-usbguard.conf,rules.d,IPCAccessControl.d}
     inst_multiple /etc/usbguard/rules.d/*
+    inst_multiple -o /etc/qubes-pci-policy.conf
     inst -l /usr/bin/usbguard
     inst -l /usr/sbin/usbguard-daemon
     inst /usr/lib/systemd/system/usbguard.service.d/30_qubes.conf


### PR DESCRIPTION
This feature can be used by advanced users to assign devices to pciback in a policy-like manner based on various PCI device attributes.

References QubesOS/qubes-issues#7886 QubesOS/qubes-issues#7792