### PR TITLE
Do not override stub grub.cfg on EFI partition

### DIFF
--- a/system-config/kernel-grub2.install
+++ b/system-config/kernel-grub2.install
@@ -22,7 +22,8 @@ if [ -x /usr/sbin/grub2-mkconfig ]; then
     if [ -e /boot/grub2/grub.cfg ]; then
         grub2-mkconfig -o /boot/grub2/grub.cfg
     fi
-    if [ -e /boot/efi/EFI/qubes/grub.cfg ]; then
+    if [ -e /boot/efi/EFI/qubes/grub.cfg ] && \
+            ! grep -q "configfile" /boot/efi/EFI/qubes/grub.cfg; then
         grub2-mkconfig -o /boot/efi/EFI/qubes/grub.cfg
     fi
 fi


### PR DESCRIPTION
Grub2 in R4.2 is made to include grub.cfg from primary /boot partition,
even on EFI systems - so it always lives in the same place. Do not not
override the config stub.

QubesOS/qubes-issues#7985