### PR TITLE
Convert policy to the new format

### DIFF
--- a/dom0-updates/qubes.ReceiveUpdates.policy
+++ b/dom0-updates/qubes.ReceiveUpdates.policy
@@ -1,6 +1,0 @@
-## Note that policy parsing stops at the first match,
-## so adding anything below "$anyvm $anyvm action" line will have no effect
-
-## Please use a single # to start your custom comments
-
-$anyvm	dom0	allow

--- a/qubes-rpc-policy/90-default-linux.policy
+++ b/qubes-rpc-policy/90-default-linux.policy
@@ -1,0 +1,8 @@
+# qubes-dom0-update
+qubes.ReceiveUpdates    * @anyvm	dom0	allow
+
+# This used to define policies for:
+# - qubes.repos.List
+# - qubes.repos.Enable
+# - qubes.repos.Disable
+# but since those are "deny" by default anyway, skip them

--- a/qubes-rpc-policy/qubes.repos.Disable
+++ b/qubes-rpc-policy/qubes.repos.Disable
@@ -1,7 +1,0 @@
-## Note that policy parsing stops at the first match,
-## so adding anything below "$anyvm $anyvm action" line will have no effect
-
-## Please use a single # to start your custom comments
-
-dom0	dom0	allow
-$anyvm	$anyvm	deny

--- a/qubes-rpc-policy/qubes.repos.Enable
+++ b/qubes-rpc-policy/qubes.repos.Enable
@@ -1,7 +1,0 @@
-## Note that policy parsing stops at the first match,
-## so adding anything below "$anyvm $anyvm action" line will have no effect
-
-## Please use a single # to start your custom comments
-
-dom0	dom0	allow
-$anyvm	$anyvm	deny

--- a/qubes-rpc-policy/qubes.repos.List
+++ b/qubes-rpc-policy/qubes.repos.List
@@ -1,7 +1,0 @@
-## Note that policy parsing stops at the first match,
-## so adding anything below "$anyvm $anyvm action" line will have no effect
-
-## Please use a single # to start your custom comments
-
-dom0	dom0	allow
-$anyvm	$anyvm	deny

--- a/qubesappmenus/qubes.SyncAppMenus.policy
+++ b/qubesappmenus/qubes.SyncAppMenus.policy
@@ -1,6 +1,0 @@
-## Note that policy parsing stops at the first match,
-## so adding anything below "$anyvm $anyvm action" line will have no effect
-
-## Please use a single # to start your custom comments
-
-$anyvm	dom0	allow

--- a/rpm_spec/core-dom0-linux.spec.in
+++ b/rpm_spec/core-dom0-linux.spec.in
@@ -100,8 +100,6 @@ make all
 %install
 
 ## Appmenus
-install -d $RPM_BUILD_ROOT/etc/qubes-rpc/policy
-cp qubesappmenus/qubes.SyncAppMenus.policy $RPM_BUILD_ROOT/etc/qubes-rpc/policy/qubes.SyncAppMenus
 make install DESTDIR=$RPM_BUILD_ROOT
 
 ### Dom0 updates
@@ -111,16 +109,18 @@ install -D dom0-updates/qubes-receive-updates $RPM_BUILD_ROOT/usr/libexec/qubes/
 install -D dom0-updates/patch-dnf-yum-config $RPM_BUILD_ROOT/usr/lib/qubes/patch-dnf-yum-config
 install -m 0644 -D dom0-updates/qubes-cached.repo $RPM_BUILD_ROOT/etc/yum.real.repos.d/qubes-cached.repo
 install -D dom0-updates/qfile-dom0-unpacker $RPM_BUILD_ROOT/usr/libexec/qubes/qfile-dom0-unpacker
+install -d $RPM_BUILD_ROOT/etc/qubes-rpc
 ln -s ../../usr/libexec/qubes/qubes-receive-updates $RPM_BUILD_ROOT/etc/qubes-rpc/qubes.ReceiveUpdates
-install -m 0664 -D dom0-updates/qubes.ReceiveUpdates.policy $RPM_BUILD_ROOT/etc/qubes-rpc/policy/qubes.ReceiveUpdates
+install -d $RPM_BUILD_ROOT/etc/qubes/policy.d/
+install -m 0644 qubes-rpc-policy/90-default-linux.policy \
+       $RPM_BUILD_ROOT/etc/qubes/policy.d/90-default-linux.policy
 
 install -d $RPM_BUILD_ROOT/var/lib/qubes/updates
 
 # Qrexec services
-mkdir -p $RPM_BUILD_ROOT/usr/lib/qubes/qubes-rpc $RPM_BUILD_ROOT/etc/qubes-rpc/policy
+mkdir -p $RPM_BUILD_ROOT/usr/lib/qubes/qubes-rpc
 cp qubes-rpc/* $RPM_BUILD_ROOT/usr/lib/qubes/qubes-rpc/
 for i in qubes-rpc/*; do ln -s ../../usr/lib/qubes/$i $RPM_BUILD_ROOT/etc/qubes-rpc/$(basename $i); done
-cp qubes-rpc-policy/* $RPM_BUILD_ROOT/etc/qubes-rpc/policy/
 
 ### pm-utils
 mkdir -p $RPM_BUILD_ROOT/usr/lib64/pm-utils/sleep.d
@@ -257,7 +257,6 @@ rm -f /lib/udev/rules.d/69-xorg-vmmouse.rules
 chmod -x /etc/grub.d/10_linux
 
 %files -f INSTALLED_FILES
-/etc/qubes-rpc/policy/qubes.SyncAppMenus
 # Dom0 updates
 /etc/cron.daily/qubes-dom0-updates.cron
 /etc/yum.real.repos.d/qubes-cached.repo
@@ -266,14 +265,11 @@ chmod -x /etc/grub.d/10_linux
 %attr(4750,root,qubes) /usr/libexec/qubes/qfile-dom0-unpacker
 /usr/libexec/qubes/qubes-receive-updates
 /etc/qubes-rpc/qubes.ReceiveUpdates
-%attr(0664,root,qubes) %config(noreplace) /etc/qubes-rpc/policy/qubes.ReceiveUpdates
+%attr(0664,root,qubes) %config(noreplace) /etc/qubes/policy.d/90-default-linux.policy
 %attr(0770,root,qubes) %dir /var/lib/qubes/updates
 # Qrexec services
 /etc/qubes-rpc/qubes.repos.*
 /usr/lib/qubes/qubes-rpc/qubes.repos.*
-%attr(0664,root,qubes) %config(noreplace) /etc/qubes-rpc/policy/qubes.repos.List
-%attr(0664,root,qubes) %config(noreplace) /etc/qubes-rpc/policy/qubes.repos.Enable
-%attr(0664,root,qubes) %config(noreplace) /etc/qubes-rpc/policy/qubes.repos.Disable
 # Dracut module
 /usr/lib/dracut/dracut.conf.d/*
 %dir %{_dracutmoddir}/90macbook12-spi-driver


### PR DESCRIPTION
1. Convert qubes.ReceiveUpdates to 90-default-linux.policy
2. Move qubes.SyncAppMenus to 90-default.policy in core-admin
3. Drop qubes.repos.*, since those are "deny" by default anyway

QubesOS/qubes-issues#8000