### PR TITLE
qvm-copy-to-vm: disable wait for GUI session

### DIFF
--- a/file-copy-vm/qvm-copy-to-vm
+++ b/file-copy-vm/qvm-copy-to-vm
@@ -36,7 +36,7 @@ mkfifo -- "$RESPONSE"
 
 # can't use $@ with --localcmd, and $* would fail on whitespace
 /usr/lib/qubes/qfile-dom0-agent "$@" <"$RESPONSE" |
-qvm-run --pass-io --service -- "$VM" "qubes.Filecopy" >"$RESPONSE"
+qvm-run --no-gui --filter-escape-chars-stderr --pass-io --service -- "$VM" "qubes.Filecopy" >"$RESPONSE"
 
 if [ "${0##*/}" = "qvm-move-to-vm" ]; then
 	rm -rf -- "$@"


### PR DESCRIPTION
This can cause the copy to hang for no good reason.  Also unconditionally filter escape characters in stderr.

Fixes: QubesOS/qubes-issues#8239.