### PR TITLE
qvm-copy-to-vm: do not wait for a GUI session in the VM

### DIFF
--- a/file-copy-vm/qvm-copy-to-vm
+++ b/file-copy-vm/qvm-copy-to-vm
@@ -36,7 +36,7 @@ mkfifo -- "$RESPONSE"
 
 # can't use $@ with --localcmd, and $* would fail on whitespace
 /usr/lib/qubes/qfile-dom0-agent "$@" <"$RESPONSE" |
-qvm-run --pass-io --service -- "$VM" "qubes.Filecopy" >"$RESPONSE"
+qvm-run --no-gui --pass-io --service -q -a -- "$VM" "qubes.Filecopy" >"$RESPONSE"
 
 if [ "${0##*/}" = "qvm-move-to-vm" ]; then
 	rm -rf -- "$@"


### PR DESCRIPTION
This ensures that copying files from dom0 to a VM works even if the GUI session in that VM doesn't.  Also add -q and -a for consistency with generated .desktop files.

Fixes: QubesOS/qubes-issues#6874.