### PR TITLE
dom0-update: avoid writing 'typescript' file

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -236,7 +236,7 @@ if [[ -t 1 ]] && [[ -t 2 ]]; then
     # We MUST NOT use ‘exec script’ here.  That causes ‘script’ to
     # inherit the child processes of the shell.  ‘script’ mishandles
     # this and enters an infinite loop.
-    CMD="script --quiet --return --command '${CMD//\'/\'\\\'\'}'"
+    CMD="script --quiet --return --command '${CMD//\'/\'\\\'\'}' /dev/null"
 fi
 
 qvm-run "${QVMRUN_OPTS[@]}" -- "$UPDATEVM" "$CMD" < /dev/null


### PR DESCRIPTION
Write `script` output to /dev/null, it doesn't need to persist. It's
main purpose is printing to the console, which is done regardless of the
output file.

Fixes QubesOS/qubes-issues#8304