### PR TITLE
Make qubes.repos.* work when called as non-root too

### DIFF
--- a/qubes-rpc/qubes.repos.Disable
+++ b/qubes-rpc/qubes.repos.Disable
@@ -7,6 +7,10 @@ import dnf
 import os
 import sys
 
+if os.getuid() != 0:
+    os.execl("/usr/bin/sudo", "sudo", "--non-interactive", "--", *sys.argv)
+    sys.exit(1)
+
 os.umask(0o022)
 
 base = dnf.Base()

--- a/qubes-rpc/qubes.repos.Enable
+++ b/qubes-rpc/qubes.repos.Enable
@@ -7,6 +7,10 @@ import dnf
 import os
 import sys
 
+if os.getuid() != 0:
+    os.execl("/usr/bin/sudo", "sudo", "--non-interactive", "--", *sys.argv)
+    sys.exit(1)
+
 os.umask(0o022)
 
 base = dnf.Base()


### PR DESCRIPTION
Qrexec service is dom0 are called as normal user. Template repos may be
writable by that user, but dom0 repos not really. Make the calls work as
non-root user too, by automatically using sudo in that case.

Fixes QubesOS/qubes-issues#8349