### PR TITLE
qubes-vm-update/dnf: import signing key if needed

### DIFF
--- a/vmupdate/agent/source/dnf/dnf_api.py
+++ b/vmupdate/agent/source/dnf/dnf_api.py
@@ -109,6 +109,17 @@ def sign_check(base, packages) -> ProcessResult:
     for package in packages:
         ret_code, message = base.package_signature_check(package)
         if ret_code != 0:
+            # Import key and re-try the check
+            try:
+                base.package_import_key(package, askcb=(lambda a, b, c: True))
+            except Exception as ex:
+                result += ProcessResult(ret_code, out="", err=str(ex))
+                continue
+            # base.package_import_key does verify package as a side effect, but
+            # do that explicitly anyway, in case the behavior would change
+            # (intentionally or not)
+            ret_code, message = base.package_signature_check(package)
+        if ret_code != 0:
             result += ProcessResult(ret_code, out="", err=message)
         else:
             result += ProcessResult(0, out=message, err="")


### PR DESCRIPTION
When an update is installed from a given repository for the first time,
its signing key may not be imported yet. Import the key as DNF would do,
and retry the signature check.