### PR TITLE
Up the limit of files downloaded during a dom0 update.

### DIFF
--- a/dom0-updates/qfile-dom0-unpacker.c
+++ b/dom0-updates/qfile-dom0-unpacker.c
@@ -14,7 +14,7 @@
 #include <libqubes-rpc-filecopy.h>
 
 #define DEFAULT_MAX_UPDATES_BYTES (4LL<<30)
-#define DEFAULT_MAX_UPDATES_FILES 2048
+#define DEFAULT_MAX_UPDATES_FILES 4096
  
 #define min(a,b) ((a) < (b) ? (a) : (b))
 #define max(a,b) ((a) > (b) ? (a) : (b))


### PR DESCRIPTION
This is totally possible during distupgrade.  I hit the issue myself. It wasn't even hard — I just have KDE stuff on my system, which is quite a lot of packages over the base dom0 system setup.