### PR TITLE
qubes-vm-update: fix false negative on apt-get update error

### DIFF
--- a/vmupdate/agent/source/apt/apt_cli.py
+++ b/vmupdate/agent/source/apt/apt_cli.py
@@ -45,6 +45,10 @@ class APTCLI(PackageManager):
         """
         cmd = [self.package_manager, "-q", "update"]
         result = self.run_cmd(cmd)
+        # 'apt-get update' reports error with exit code 100, but updater as a
+        # whole reserves it for "no updates"
+        if result.code == 100:
+            result.code = 1
         result.error_from_messages()
         return result
 


### PR DESCRIPTION
apt-get update exits with code 100 on error, but updater as a whole uses
this code for "no update". Translate code 100 in this place to 1.

Fixes QubesOS/qubes-issues#8898