### PR TITLE
Workaround for starting updater with /run noexec

### DIFF
--- a/vmupdate/qube_connection.py
+++ b/vmupdate/qube_connection.py
@@ -160,7 +160,7 @@ class QubeConnection:
         result = self._run_shell_command_in_qube(self.qube, command)
 
         # run entrypoint
-        command = [entrypoint_path, *AgentArgs.to_cli_args(agent_args)]
+        command = ["python3", entrypoint_path, *AgentArgs.to_cli_args(agent_args)]
         result += self._run_shell_command_in_qube(
             self.qube, command, show=self.show_progress)
 


### PR DESCRIPTION
On some Debian systems /run is mounted as noexec. Since the updater is copied to /run, it fails to execute on these systems.

Fixes QubesOS/qubes-issues#8493