### PR TITLE
updater: use the same python interpreter as in `entrypoint.py`

### DIFF
--- a/vmupdate/qube_connection.py
+++ b/vmupdate/qube_connection.py
@@ -45,6 +45,8 @@ class QubeConnection:
        stop the qube if it was started by this connection.
     """
 
+    PYTHON_PATH = "/usr/bin/python3"
+
     def __init__(
             self,
             qube,
@@ -160,7 +162,8 @@ class QubeConnection:
         result = self._run_shell_command_in_qube(self.qube, command)
 
         # run entrypoint
-        command = ["python3", entrypoint_path, *AgentArgs.to_cli_args(agent_args)]
+        command = [QubeConnection.PYTHON_PATH, entrypoint_path,
+                   *AgentArgs.to_cli_args(agent_args)]
         result += self._run_shell_command_in_qube(
             self.qube, command, show=self.show_progress)
 


### PR DESCRIPTION
We should use `/usr/bin/python3` or `/bin/python3`. Using just `python3` can break updater.

fixes QubesOS/qubes-issues/issues/9200