### PR TITLE
vmupdate/dnf: use --setopt=obsoletes=1 instead of --obsoletes

### DIFF
--- a/vmupdate/agent/source/dnf/dnf_cli.py
+++ b/vmupdate/agent/source/dnf/dnf_cli.py
@@ -95,7 +95,7 @@ class DNFCLI(PackageManager):
         Disable or enforce obsolete flag in dnf/yum.
         """
         if remove_obsolete:
-            return ["-y", "--obsoletes", "upgrade"]
+            return ["-y", "--setopt=obsoletes=1", "upgrade"]
         return ["-y", "--setopt=obsoletes=0",
                 "upgrade" if self.package_manager == "dnf" else "update"]
 


### PR DESCRIPTION
DNF5 dropped that CLI option, but the config option remained:
https://github.com/rpm-software-management/dnf5/blob/main/doc/changes_from_dnf4.7.rst

QubesOS/qubes-issues#9244