### PR TITLE
Unite setopt argument with equal sign

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -76,12 +76,16 @@ while [ $# -gt 0 ]; do
             GUI=1
             UPDATEVM_OPTS+=( "$1" )
             ;;
-        --show-output)
-            # ignore
-            ;;
         --check-only)
             CHECK_ONLY=1
             UPDATEVM_OPTS+=( "$1" )
+            ;;
+        --setopt)
+            UPDATEVM_OPTS+=( "$1=$2" )
+            shift
+            ;;
+        --show-output)
+            # ignore
             ;;
         --preserve-terminal)
             # ignore


### PR DESCRIPTION
Avoid qubes-dom0-update treating the setopt value as a command to dnf.

Fix: https://github.com/QubesOS/qubes-issues/issues/9509