### PR TITLE
vmupdate: wait for other apt-get to complete

### DIFF
--- a/vmupdate/agent/source/apt/apt_api.py
+++ b/vmupdate/agent/source/apt/apt_api.py
@@ -53,6 +53,7 @@ class APT(APTCLI):
         :param hard_fail: raise error if some repo is unavailable
         :return: (exit_code, stdout, stderr)
         """
+        self.wait_for_lock()
         result = ProcessResult()
         try:
             self.log.debug("Refreshing available packages...")


### PR DESCRIPTION
If there is an `apt-get update` running in the background (for example
periodical updates check), running another would fail. Since `apt-get`
itself doesn't have an option to wait for the lock, wait for it in the
updater tool. It's not perfect - there is still a window where another
apt-get instance can start, but at least this will handle the (more
common) situation when it's already running.