### PR TITLE
vmupdate: fix waiting for the other apt-get process

### DIFF
--- a/vmupdate/agent/source/apt/apt_cli.py
+++ b/vmupdate/agent/source/apt/apt_cli.py
@@ -42,8 +42,8 @@ class APTCLI(PackageManager):
         """
         Wait for any other apt-get instance to finish.
         """
-        with open("/var/lib/apt/lists/lock") as f_lock:
-            fcntl.flock(f_lock.fileno(), fcntl.LOCK_EX)
+        with open("/var/lib/apt/lists/lock", "rb+") as f_lock:
+            fcntl.lockf(f_lock.fileno(), fcntl.LOCK_EX)
 
     def refresh(self, hard_fail: bool) -> ProcessResult:
         """


### PR DESCRIPTION
apt-get uses fcntl F_SETLK for locking, not flock(). Update the function
accordingly.

Fixes: 8fa2929 "vmupdate: wait for other apt-get to complete"