### PR TITLE
vmupdate: Apply early fix for meminfo-writer SELinux label

### DIFF
--- a/vmupdate/agent/source/plugins/fix_meminfo_writer_label.py
+++ b/vmupdate/agent/source/plugins/fix_meminfo_writer_label.py
@@ -1,0 +1,35 @@
+import subprocess
+
+
+def fix_meminfo_writer_label(os_data, log, **kwargs):
+    """
+    Fix meminfo-writer SELinux label to make memory ballooning work again
+
+    # https://github.com/QubesOS/qubes-issues/issues/9663
+    """
+
+    if os_data["id"] == "fedora":
+        meminfo_path = "/usr/sbin/meminfo-writer"
+        expected_label = "qubes_meminfo_writer_exec_t"
+
+        label_changed = False
+        try:
+            output = subprocess.check_output(
+                ["ls", "-Z", meminfo_path], universal_newlines=True
+            )
+            if expected_label not in output:
+                subprocess.check_call(["chcon", "-t", expected_label, meminfo_path])
+                log.info(
+                    f"SELinux label for {meminfo_path} changed to '{expected_label}'"
+                )
+                label_changed = True
+        except subprocess.CalledProcessError as e:
+            log.error(f"Error processing {meminfo_path}: {e}")
+
+        if label_changed:
+            try:
+                subprocess.check_call(["systemctl", "restart", "qubes-meminfo-writer"])
+                log.info("qubes-meminfo-writer service restarted")
+            except subprocess.CalledProcessError as e:
+                log.error(f"Error restarting qubes-meminfo-writer service: {e}")
+


### PR DESCRIPTION
The relevant package updates are supposed to fix the label anyway, but
before that the template has too little memory to apply the update
reliably (most of the time it works, but not always). Apply the label
fix early to have more memory when installing updates.

Script by Minimalist <suspectindustrie@protonmail.com>

QubesOS/qubes-issues#9663