### PR TITLE
vmupdate: Fix SELinux plugin detection

### DIFF
--- a/vmupdate/agent/source/plugins/fix_meminfo_writer_label.py
+++ b/vmupdate/agent/source/plugins/fix_meminfo_writer_label.py
@@ -1,4 +1,5 @@
 import subprocess
+import os
 
 
 def fix_meminfo_writer_label(os_data, log, **kwargs):
@@ -9,27 +10,32 @@ def fix_meminfo_writer_label(os_data, log, **kwargs):
     """
 
     if os_data["id"] == "fedora":
-        meminfo_path = "/usr/sbin/meminfo-writer"
-        expected_label = "qubes_meminfo_writer_exec_t"
+        if os.path.exists("/usr/sbin/selinuxenabled"):
+            meminfo_path = "/usr/sbin/meminfo-writer"
+            expected_label = "qubes_meminfo_writer_exec_t"
 
-        label_changed = False
-        try:
-            output = subprocess.check_output(
-                ["ls", "-Z", meminfo_path], universal_newlines=True
-            )
-            if expected_label not in output:
-                subprocess.check_call(["chcon", "-t", expected_label, meminfo_path])
-                log.info(
-                    f"SELinux label for {meminfo_path} changed to '{expected_label}'"
-                )
-                label_changed = True
-        except subprocess.CalledProcessError as e:
-            log.error(f"Error processing {meminfo_path}: {e}")
-
-        if label_changed:
+            label_changed = False
             try:
-                subprocess.check_call(["systemctl", "restart", "qubes-meminfo-writer"])
-                log.info("qubes-meminfo-writer service restarted")
+                if subprocess.call(["/usr/sbin/selinuxenabled"]) == 0:
+                    output = subprocess.check_output(
+                        ["ls", "-Z", meminfo_path], universal_newlines=True
+                    )
+                    if expected_label not in output:
+                        subprocess.check_call(
+                            ["chcon", "-t", expected_label, meminfo_path]
+                        )
+                        log.info(
+                            f"SELinux label for {meminfo_path} changed to '{expected_label}'"
+                        )
+                        label_changed = True
             except subprocess.CalledProcessError as e:
-                log.error(f"Error restarting qubes-meminfo-writer service: {e}")
+                log.error(f"Error processing {meminfo_path}: {e}")
 
+            if label_changed:
+                try:
+                    subprocess.check_call(
+                        ["systemctl", "restart", "qubes-meminfo-writer"]
+                    )
+                    log.info("qubes-meminfo-writer service restarted")
+                except subprocess.CalledProcessError as e:
+                    log.error(f"Error restarting qubes-meminfo-writer service: {e}")


### PR DESCRIPTION
The current plugin always run if the system is detected as fedora. But, SELinux is not always installed (minimal templates for example) or it can be intentionally disabled by the user, meaning the script will throw a chcon error in the update log. Fix that by first checking if SELinux is installed, and then check if the status is Enforcing/Permissive.

https://github.com/QubesOS/qubes-issues/issues/9663