### PR TITLE
Make the qubes-pciback module omittable

### DIFF
--- a/dracut/dracut.conf.d/30-qubes.conf
+++ b/dracut/dracut.conf.d/30-qubes.conf
@@ -7,11 +7,6 @@ add_dracutmodules+=" extra-modules "
 # pciback kernel module.
 omit_dracutmodules+=" network kernel-network-modules "
 
-# This is to include Qubes-specific dracut module that takes care of
-# detecting and hiding all networking devices at boot time
-# so that Dom0 doesn't load drivers for them...
-add_dracutmodules+=" qubes-pciback "
-
 # reduced syslog verbosity avoids lsinitrd call - this avoids 'cat: Broken
 # pipe' confusing message, but also makes dracut call faster.
 sysloglvl=4

--- a/dracut/modules.d/90qubes-pciback/module-setup.sh
+++ b/dracut/modules.d/90qubes-pciback/module-setup.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# This is a Qubes-specific dracut module that takes care of detecting and
+# hiding all networking devices (and optionally USB devices) at boot time so
+# that Dom0 doesn't load drivers for them...
+
+check() {
+    return 0
+}
 
 install () {
     inst_hook cmdline 02 "$moddir/qubes-pciback.sh"


### PR DESCRIPTION
On my system I have an alternative solution to `qubes-pciback`, which allows fido2 disk crypto (and fixes a hardware specific issue [QubesOS/qubes-issues#8794](https://github.com/QubesOS/qubes-issues/issues/8794)). Unfortunately it's not compatible with `qubes-pciback`. 

The problem I'm having with `qubes-pciback` is that it's included twice into dracut:
1. It's activated by default (by not having a `check()` function in `module-setup.sh`, which defaults to *include by default*).
2. It's explicitly added through `dracut.conf.d/30-qubes.conf`.
 
The `check()` function can be overridden using `omit_dracutmodules+=`, but `add_dracutmodules+=` can't. Since `30-qubes.conf` is managed by dnf/rpm, changes to it are volatile, meaning that any setup which requires `qubes-pciback` to be disabled breaks whenever `qubes-core-dom0-admin` is updated.

This pull request removes `qubes-pciback` from `30-qubes.conf` and adds an explicit `check()` function to the module which includes `qubes-pciback` by default. As far as I can tell from my testing and from the documentation, this will retain the exact previous behavior unless the user adds `omit_dracutmodules+=" qubes-pciback "` to a dracut config file.