### PR TITLE
vmupdate: load plugins in sorted order

### DIFF
--- a/vmupdate/agent/source/plugins/__init__.py
+++ b/vmupdate/agent/source/plugins/__init__.py
@@ -1,7 +1,7 @@
 import importlib
 import os.path
 import glob
-modules = glob.glob(os.path.join(os.path.dirname(__file__), "*.py"))
+modules = sorted(glob.glob(os.path.join(os.path.dirname(__file__), "*.py")))
 __all__ = [os.path.basename(f)[:-3]
            for f in modules if os.path.isfile(f)
            and not f.endswith('__init__.py')]


### PR DESCRIPTION
Ensure deterministic load order, but also allow a bit of control over
that order. There may be plugin that wants to be loaded before others.