### PR TITLE
vmupdate: Fix `meminfo-writer` SELinux label for both bin & sbin

### DIFF
--- a/vmupdate/agent/source/plugins/fix_meminfo_writer_label.py
+++ b/vmupdate/agent/source/plugins/fix_meminfo_writer_label.py
@@ -12,7 +12,10 @@ def fix_meminfo_writer_label(os_data, log, **kwargs):
 
     if os_data["id"] == "fedora":
         if os.path.exists("/usr/sbin/selinuxenabled"):
-            meminfo_path = "/usr/sbin/meminfo-writer"
+            if os.path.exists("/usr/bin/meminfo-writer"):
+                meminfo_path = "/usr/bin/meminfo-writer"
+            else:
+                meminfo_path = "/usr/sbin/meminfo-writer"
             expected_label = "qubes_meminfo_writer_exec_t"
 
             label_changed = False


### PR DESCRIPTION
Since `meminfo-writer` is moved from `/usr/sbin` to `/usr/bin`, the patch should look for both scenarios and apply the patch accordingly