### PR TITLE
vmupdate: don't fail if apt lock file doesn't exist

### DIFF
--- a/vmupdate/agent/source/apt/apt_cli.py
+++ b/vmupdate/agent/source/apt/apt_cli.py
@@ -52,6 +52,8 @@ class APTCLI(PackageManager):
         """
         Wait for any other apt-get instance to finish.
         """
+        if not os.path.exists("/var/lib/apt/lists/lock"):
+            return
         with self.apt_lock():
             pass
 


### PR DESCRIPTION
This is the case after fresh template installation.

Fixes QubesOS/qubes-issues#9857