### PR TITLE
dracut: include xhci-pci-renesas too

### DIFF
--- a/dracut/modules.d/90extra-modules/module-setup.sh
+++ b/dracut/modules.d/90extra-modules/module-setup.sh
@@ -5,7 +5,7 @@ installkernel() {
     # ehci-hcd split off
     hostonly='' instmods ehci-pci ehci-platform || :
     # xhci-hcd split off
-    hostonly='' instmods xhci-pci xhci-plat-hcd || :
+    hostonly='' instmods xhci-pci xhci-plat-hcd xhci-pci-renesas || :
     # ohci-hcd split off
     hostonly='' instmods ohci-pci || :
     # workaround for https://github.com/dracutdevs/dracut/issues/712


### PR DESCRIPTION
This is yet another module that is used by (a bit less) common USB
controller. Include it in initramfs so it can be used to enter the LUKS
passphrase.

Fixes QubesOS/qubes-issues#9889