### PR TITLE
add Zenity to dependencies

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -421,7 +421,11 @@ else
     fi
     echo "No updates available" >&2
     if [ "$GUI" == "1" ]; then
-        zenity --info --title='Dom0 updates' --text='No updates available'
+        if [ "$KDE_FULL_SESSION" ]; then
+            kdialog --msgbox 'No updates available'
+        else
+            zenity --info --title='Dom0 updates' --text='No updates available'
+        fi
     fi
 fi
 

--- a/rpm_spec/core-dom0-linux.spec.in
+++ b/rpm_spec/core-dom0-linux.spec.in
@@ -54,6 +54,7 @@ Requires:	xdotool
 Requires:	createrepo_c
 Requires:	rpm >= 4.14
 Requires:	systemd-udev
+Requires:	(zenity or kdialog)
 # Needed for USB in dom0
 Requires: usbguard
 # salt needs to pass --console --show-output options now


### PR DESCRIPTION
Some small programs uses Zenity to show dialogs.
Fixes: QubesOS/qubes-issues#7280