### PR TITLE
vmupdate: answer "yes" to the import key question

### DIFF
--- a/vmupdate/agent/source/dnf/dnf_cli.py
+++ b/vmupdate/agent/source/dnf/dnf_cli.py
@@ -53,6 +53,7 @@ class DNFCLI(PackageManager):
         cmd = [self.package_manager,
                "-q",
                "check-update",
+               "--assumeyes",
                f"--setopt=skip_if_unavailable={int(not hard_fail)}"]
         result_check = self.run_cmd(cmd)
         # ret_code == 100 is not an error


### PR DESCRIPTION
When fetching repository metadata for the first time, dnf will ask for
confirmation on importing metadata signing key. Since the key is
imported from the local filesystem, it's safe to do, so do it
automatically.

QubesOS/qubes-issues#9807