### PR TITLE
vmupdate: fix --apps flag

### DIFF
--- a/vmupdate/vmupdate.py
+++ b/vmupdate/vmupdate.py
@@ -186,7 +186,7 @@ def preselect_targets(args, app) -> Set[qubesadmin.vm.QubesVM]:
             targets.update([vm for vm in updatable
                             if vm.klass == 'StandaloneVM'])
         if args.apps:
-            targets.update({vm for vm in updatable
+            targets.update({vm for vm in app.domains
                             if vm.klass == 'AppVM' and vm.is_running()})
 
     # user can target non-updatable vm if she like


### PR DESCRIPTION
The feature `qubes-vm-update --apps` does not work as it never selects any AppVM, the point of this flag is to update all running AppVM so you don't have to restart them. Of course, and it's in the documentation, changes will be lost after reboot, this does not prevent from updating according templates, but this allows you to update without stopping work / running stuff.

After this change, it only works with the associated flag `--force-update` because there are no known information about available updates for an appvm, and this is not pulled from the template information either.

Thanks @alimirjamali for the diff!