### PR TITLE
vmupdate: disable SELinux during update

### DIFF
--- a/vmupdate/agent/source/plugins/fix_meminfo_writer_label.py
+++ b/vmupdate/agent/source/plugins/fix_meminfo_writer_label.py
@@ -32,6 +32,11 @@ def fix_meminfo_writer_label(os_data, log, **kwargs):
                             f"SELinux label for {meminfo_path} changed to '{expected_label}'"
                         )
                         label_changed = True
+                    # Disable SELinux for the update time, to avoid
+                    # half-updated policy interrupting the process. This is
+                    # workaround for
+                    # https://bugzilla.redhat.com/show_bug.cgi?id=2380156
+                    subprocess.check_call(["setenforce", "0"])
             except subprocess.CalledProcessError as e:
                 log.error(f"Error processing {meminfo_path}: {e}")
 


### PR DESCRIPTION
Apparently some packages (chromium) may load half-assembled SELinux
policy during the update. Later in the update process the policy gets
rebuilt and loaded again, so after the update all should be fine. But if
the update gets interrupted by such half-installed policy, it won't
work.

Workaround the issue by disabling SELinux before the update. It will get
enabled again the next time VM starts.

Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2380156
Fixes QubesOS/qubes-issues#10054
Fixes QubesOS/qubes-issues#9663