### PR TITLE
Enable only one display manager

### DIFF
--- a/system-config/75-qubes-dom0.preset
+++ b/system-config/75-qubes-dom0.preset
@@ -1,10 +1,9 @@
-enable gdm.service
 enable lightdm.service
-enable slim.service
-enable lxdm.service
-enable sddm.service
-enable kdm.service
-enable xdm.service
+#enable slim.service
+#enable lxdm.service
+#enable sddm.service
+#enable kdm.service
+#enable xdm.service
 
 
 disable systemd-timesyncd.service


### PR DESCRIPTION
They all have `Alias=display-manager.service` in the unit file, and
having more of them enabled at the same time causes conflicts (for
example `systemctl preset` call during installation fails, same as
`systemctl preset-all` on release upgrade.