### PR TITLE
Remove redundant /1 from clock sync cron

### DIFF
--- a/system-config/qubes-sync-clock.cron
+++ b/system-config/qubes-sync-clock.cron
@@ -1,1 +1,1 @@
-0 */1 * * * root /usr/bin/qvm-sync-clock > /dev/null 2>&1 || true
+0 * * * * root /usr/bin/qvm-sync-clock > /dev/null 2>&1 || true


### PR DESCRIPTION
@parulin

Fixes [qubes-issues/10481](https://github.com/QubesOS/qubes-issues/issues/10481).

(Untested - changed it on my deployment and will report if anything bad happens).