### PR TITLE
Replace `fgrep` with `grep -F` to avoid a warning

### DIFF
--- a/system-config/kernel-xen-efi.install
+++ b/system-config/kernel-xen-efi.install
@@ -38,7 +38,7 @@ case "$COMMAND" in
             dracut -f "$EFI_DIR/initramfs-${KVER}.img" "$KVER"
         fi
 
-        if ! fgrep -q "[${KVER}]" $EFI_DIR/xen.cfg; then
+        if ! grep -F -q "[${KVER}]" $EFI_DIR/xen.cfg; then
             # take the default section and use it as a template for the new entry
             awk -F = --assign "kver=${KVER}" '
               /^\[/ {


### PR DESCRIPTION
Today, I updated the dom0 kernel of my Qubes 4.3 system and saw a bunch of "warning: fgrep is obsolescent; using grep -F" messages.  This change (if backported) should stop those messages, FWIW.  Untested but hopefully obviously correct.