### PR TITLE
validate env limits in qfile-dom0-unpacker

### DIFF
--- a/dom0-updates/Makefile
+++ b/dom0-updates/Makefile
@@ -1,4 +1,4 @@
 CC=gcc
 CFLAGS=-g -I. -Wall -Wextra -Werror -fPIC -pie
 qfile-dom0-unpacker: qfile-dom0-unpacker.o
-	$(CC) -pie -g -o $@ $^ -lqubes-rpc-filecopy
+	$(CC) -pie -g -o $@ $^ -lqubes-rpc-filecopy -lqubes-pure

--- a/dom0-updates/qfile-dom0-unpacker.c
+++ b/dom0-updates/qfile-dom0-unpacker.c
@@ -19,6 +19,32 @@
 #define min(a,b) ((a) < (b) ? (a) : (b))
 #define max(a,b) ((a) > (b) ? (a) : (b))
 
+static long long parse_limit_env(const char *name, long long fallback)
+{
+    const char *value = getenv(name);
+    if (!value)
+        return fallback;
+
+    if (*value < '0' || *value > '9') {
+        fprintf(stderr, "Invalid value for %s: %s\n", name, value);
+        exit(1);
+    }
+
+    errno = 0;
+    char *end = NULL;
+    long long limit = strtoll(value, &end, 10);
+    if (errno == ERANGE || *end != '\0' || limit < 0) {
+        fprintf(stderr, "Invalid value for %s: %s\n", name, value);
+        exit(1);
+    }
+    if (limit == 0 && strcmp(value, "0") != 0) {
+        fprintf(stderr, "Invalid value for %s: %s\n", name, value);
+        exit(1);
+    }
+
+    return limit;
+}
+
 int prepare_creds_return_uid(const char *username)
 {
     struct passwd *pwd;
@@ -88,10 +114,8 @@ int main(int argc, char ** argv)
         perror("Failed to check free space");
     }
 
-    if ((var=getenv("UPDATES_MAX_BYTES")))
-        bytes_limit = atoll(var);
-    if ((var=getenv("UPDATES_MAX_FILES")))
-        files_limit = atoll(var);
+    bytes_limit = parse_limit_env("UPDATES_MAX_BYTES", bytes_limit);
+    files_limit = parse_limit_env("UPDATES_MAX_FILES", files_limit);
 
     set_size_limit(bytes_limit, files_limit);
 

--- a/dom0-updates/qfile-dom0-unpacker.c
+++ b/dom0-updates/qfile-dom0-unpacker.c
@@ -26,19 +26,23 @@ static long long parse_limit_env(const char *name, long long fallback)
         return fallback;
 
     if (*value < '0' || *value > '9') {
-        fprintf(stderr, "Invalid value for %s: %s\n", name, value);
+        fprintf(stderr, "Invalid value for %s: %s: not a non-negative integer\n", name, value);
         exit(1);
     }
 
     errno = 0;
     char *end = NULL;
     long long limit = strtoll(value, &end, 10);
-    if (errno == ERANGE || *end != '\0' || limit < 0) {
-        fprintf(stderr, "Invalid value for %s: %s\n", name, value);
+    if (errno == ERANGE) {
+        fprintf(stderr, "Invalid value for %s: %s: out of range\n", name, value);
+        exit(1);
+    }
+    if (*end != '\0') {
+        fprintf(stderr, "Invalid value for %s: %s: trailing non-numeric characters\n", name, value);
         exit(1);
     }
     if (limit == 0 && strcmp(value, "0") != 0) {
-        fprintf(stderr, "Invalid value for %s: %s\n", name, value);
+        fprintf(stderr, "Invalid value for %s: %s: invalid zero representation\n", name, value);
         exit(1);
     }
 

--- a/dom0-updates/qfile-dom0-unpacker.c
+++ b/dom0-updates/qfile-dom0-unpacker.c
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <libqubes-rpc-filecopy.h>
+#include <qubes/pure.h>
 
 #define DEFAULT_MAX_UPDATES_BYTES (4LL<<30)
 #define DEFAULT_MAX_UPDATES_FILES 4096
@@ -25,24 +26,14 @@ static long long parse_limit_env(const char *name, long long fallback)
     if (!value)
         return fallback;
 
-    if (*value < '0' || *value > '9') {
-        fprintf(stderr, "Invalid value for %s: %s: not a non-negative integer\n", name, value);
-        exit(1);
-    }
-
-    errno = 0;
-    char *end = NULL;
-    long long limit = strtoll(value, &end, 10);
-    if (errno == ERANGE) {
+    long long limit;
+    int rc = qubes_pure_parse_nonneg_ll(value, &limit);
+    if (rc == -ERANGE) {
         fprintf(stderr, "Invalid value for %s: %s: out of range\n", name, value);
         exit(1);
     }
-    if (*end != '\0') {
-        fprintf(stderr, "Invalid value for %s: %s: trailing non-numeric characters\n", name, value);
-        exit(1);
-    }
-    if (limit == 0 && strcmp(value, "0") != 0) {
-        fprintf(stderr, "Invalid value for %s: %s: invalid zero representation\n", name, value);
+    if (rc != 0) {
+        fprintf(stderr, "Invalid value for %s: %s: not a valid non-negative integer\n", name, value);
         exit(1);
     }
 


### PR DESCRIPTION
### Summary 

This change fixes unsafe parsing of UPDATES_MAX_BYTES and UPDATES_MAX_FILES in qfile-dom0-unpacker.

The current implementation uses atoll(), which silently returns 0 on invalid input. Since 0 is interpreted as “no limit”, malformed or unintended values (e.g., non-numeric strings) can effectively disable limits without any error. In the context of copying data into dom0, this results in a fail-open behavior and weakens expected safeguards.

This patch replaces atoll() with strtoll() and adds strict validation. The parsing now:
- rejects non-numeric and malformed inputs
- rejects partial parses (e.g., trailing characters)
- rejects overflow conditions (ERANGE)
- rejects negative values
- accepts 0 only when explicitly provided as "0"

Any invalid input results in an error message and immediate exit, enforcing fail-closed semantics.

This ensures that user misconfiguration cannot silently remove limits and aligns the behavior with the expectation that invalid input must not degrade safety guarantees.

Fixes QubesOS/qubes-issues#8882