### PR TITLE
dom0-update: don't fail if there is nothing to install

### DIFF
--- a/dom0-updates/qubes-dom0-update
+++ b/dom0-updates/qubes-dom0-update
@@ -472,7 +472,11 @@ fi
 
 if [ ${#PKGS[@]} -gt 0 ]; then
 
-    dnf $YUM_ACTION "${YUM_OPTS[@]}" "${PKGS[@]}" ; RETCODE=$?
+    if [ -f /var/lib/qubes/updates/repodata/repomd.xml ]; then
+        dnf $YUM_ACTION "${YUM_OPTS[@]}" "${PKGS[@]}" ; RETCODE=$?
+    else
+        echo "Nothing downloaded" >&2
+    fi
 
 elif [ -f /var/lib/qubes/updates/repodata/repomd.xml ]; then
     # Above file exists only when at least one package was downloaded


### PR DESCRIPTION
Do not fail the whole qubes-dom0-update call if download completed with
exit code 0 but didn't sent any packages. This usually means the
requested package is already installed.

Fixes QubesOS/qubes-issues#10316