### PR TITLE
vmupdate: add qvm-template-upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ rpm/
 pkgs/
 
 __pycache__/
+*.egg-info/

--- a/doc/tools/qvm-template-upgrade.rst
+++ b/doc/tools/qvm-template-upgrade.rst
@@ -1,0 +1,73 @@
+====================
+qvm-template-upgrade
+====================
+
+NAME
+====
+qvm-template-upgrade - clone a qube and upgrade the clone to the next distribution release
+
+SYNOPSIS
+========
+| qvm-template-upgrade --template=<NAME> [OPTIONS]
+
+OPTIONS
+=======
+
+--template=<NAME>
+    Name of the source TemplateVM or StandaloneVM. This option is required.
+--new-name=<NAME>
+    Name for the clone. By default, replaces the last occurrence of the current ``os-version`` in the source name.
+--keep-new-on-failure
+    Keep the clone if the in-qube upgrade fails so that it can be inspected.
+--dry-run
+    Run dom0 preflight validation and print the planned source, clone name, distribution, and target release without creating a clone.
+--log=<LEVEL>
+    Set the workflow and in-qube agent log level.
+    Accepted values are ``DEBUG``, ``INFO`` (default), ``WARNING``, ``ERROR``, and ``CRITICAL``.
+-v, --verbose
+    Increase qubesadmin client verbosity.
+-q, --quiet
+    Decrease qubesadmin client verbosity.
+-h, --help
+    Show this help message and exit.
+
+CLONE NAME DERIVATION
+=====================
+
+Unless ``--new-name`` is specified, the last occurrence of the current version in the source name is replaced with the target version. If the current version is absent, the target version is appended:
+
+- ``fedora-41`` becomes ``fedora-42``.
+- ``fedora-41-minimal`` becomes ``fedora-42-minimal``.
+- ``custom-vm`` becomes ``custom-vm-42``.
+
+RETURN CODES
+============
+
+0:   The upgrade or dry run completed. A metadata-write warning after an otherwise successful upgrade also returns this status.
+
+1:   Clone creation, qrexec transport, or the in-qube upgrade failed.
+
+2:   Command-line parsing error.
+
+64:  Dom0 preflight validation error, such as an unsupported source qube, missing distribution features, a non-integer version, or an existing target name.
+
+130: Interrupted by the user. The clone may remain.
+
+FILES
+=====
+
+``/var/log/qubes/qvm-template-upgrade.log``
+    Main workflow log. If the file cannot be opened, the command continues with stderr logging only.
+
+``/var/log/qubes/update-<CLONE_NAME>.log``
+    Detailed qrexec transport and in-qube agent log. This file is created after the agent starts.
+
+SEE ALSO
+========
+
+**qubes-vm-update**\ (1), **qvm-clone**\ (1), **qvm-features**\ (1), **qvm-template**\ (1)
+
+AUTHORS
+=======
+| Nihal Kumar <nihalxkumar at tutamail dot com>
+| Ben Grande <ben at invisiblethingslab dot com>

--- a/doc/tools/qvm-template-upgrade.rst
+++ b/doc/tools/qvm-template-upgrade.rst
@@ -1,0 +1,102 @@
+====================
+qvm-template-upgrade
+====================
+
+NAME
+====
+qvm-template-upgrade - upgrade a clone to the next distribution release
+
+SYNOPSIS
+========
+| qvm-template-upgrade --template=<NAME> [OPTIONS]
+
+DESCRIPTION
+===========
+Clone the source qube and run the distribution release upgrade inside the
+clone. Agent output is streamed to the terminal above a progress bar and
+written to the log files listed in FILES. The progress bar is skipped when
+stderr is not a terminal.
+
+OPTIONS
+=======
+
+--template=<NAME>
+    Name of the source TemplateVM or StandaloneVM. This option is required.
+--new-name=<NAME>
+    Name for the clone. By default, replace the final ``os-version`` in the source name.
+--keep-new-on-failure
+    Keep the clone if the in-qube upgrade fails so that it can be inspected.
+--dry-run
+    Validate inputs and print the plan without creating a clone.
+--log=<LEVEL>
+    Set the workflow and in-qube agent log level.
+    Accepted values (case-insensitive) are ``DEBUG``, ``INFO`` (default), ``WARNING``, ``ERROR``, and ``CRITICAL``.
+-v, --verbose
+    Increase qubesadmin client verbosity.
+-q, --quiet
+    Decrease qubesadmin client verbosity.
+-h, --help
+    Show this help message and exit.
+
+CLONE NAME DERIVATION
+=====================
+
+Unless ``--new-name`` is set, replace the final current version. Append the
+target version when it is absent:
+
+- ``fedora-41`` becomes ``fedora-42``.
+- ``fedora-41-minimal`` becomes ``fedora-42-minimal``.
+- ``custom-vm`` becomes ``custom-vm-42``.
+
+TEMPLATE METADATA
+=================
+
+After a TemplateVM upgrade, update these ``template-*`` features:
+
+- ``template-name`` is set to the clone's name.
+- ``template-installtime`` and ``template-buildtime`` are set to the time of the upgrade, since the clone's root filesystem was produced then.
+- ``template-reponame`` is set to ``@qvm-template-upgrade``, marking the qube as neither installed from a repository nor from a local package.
+- ``template-summary`` and ``template-description`` have every occurrence of the source qube's name replaced with the clone's. Any other text is user-authored and is left alone.
+
+``template-epoch``, ``template-version``, and ``template-release`` stay
+inherited. **qvm-template**\ (1) uses them for package comparisons.
+
+StandaloneVMs are not managed by **qvm-template**\ (1), so none of their ``template-*`` features are modified.
+
+The inherited version makes **qvm-template**\ (1) list the clone as
+upgradeable. ``qvm-template upgrade`` would replace it with a stock template.
+
+RETURN CODES
+============
+
+0:   The upgrade or dry run completed. A metadata-write warning after an otherwise successful upgrade also returns this status.
+
+1:   Clone creation, qrexec transport, or the in-qube upgrade failed.
+
+2:   Command-line parsing error.
+
+64:  Dom0 preflight validation error, such as an unsupported source qube, a derivative distribution with its own version numbering, missing distribution features, a non-integer version, or an existing target name.
+
+130: Interrupted by the user. The clone may remain.
+
+FILES
+=====
+
+``/var/log/qubes/qvm-template-upgrade.log``
+    Main workflow log. If the file cannot be opened, the command continues with stderr logging only.
+
+``/var/log/qubes/update-<CLONE_NAME>.log``
+    Detailed qrexec transport and in-qube agent log. This file is created after the agent starts.
+
+SEE ALSO
+========
+
+**qubes-vm-update**\ (1), **qvm-clone**\ (1), **qvm-features**\ (1), **qvm-template**\ (1)
+
+AUTHORS
+=======
+This command was written by Nihal Kumar <nihalxkumar at tutamail dot com> as part of Google Summer of Code.
+
+Ben Grande <ben at invisiblethingslab dot com> reviewed the change.
+
+It was inspired by a personal project by Kenneth R. Rosen <kennethrrosen at proton dot me>.

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,10 @@ if __name__ == "__main__":
         url="https://www.qubes-os.org/",
         packages=setuptools.find_packages(include=("vmupdate", "vmupdate*")),
         entry_points={
-            "console_scripts": "qubes-vm-update = vmupdate.vmupdate:main",
+            "console_scripts": [
+                "qubes-vm-update = vmupdate.vmupdate:main",
+                "qvm-template-upgrade = "
+                "vmupdate.template_upgrade:main",
+            ],
         },
     )

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ if __name__ == "__main__":
         url="https://www.qubes-os.org/",
         packages=setuptools.find_packages(include=("vmupdate", "vmupdate*")),
         entry_points={
-            "console_scripts": "qubes-vm-update = vmupdate.vmupdate:main",
+            "console_scripts": [
+                "qubes-vm-update = vmupdate.vmupdate:main",
+                "qvm-template-upgrade = vmupdate.template_upgrade:main",
+            ],
         },
     )

--- a/vmupdate/agent/entrypoint.py
+++ b/vmupdate/agent/entrypoint.py
@@ -32,15 +32,35 @@ def main(args=None):
         os_data, log, log_handler, log_level, agent_type, args.no_progress
     )
 
-    log.debug("Running upgrades.")
-    return_code = pkg_mng.upgrade(
-        refresh=not args.no_refresh,
-        hard_fail=not args.force_upgrade,
-        remove_obsolete=not args.leave_obsolete,
-        print_streams=args.show_output,
-    )
+    if args.version_upgrade:
+        log.debug(
+            "Running distribution version upgrade to %s.",
+            args.version_upgrade,
+        )
+        try:
+            return_code = pkg_mng.version_upgrade(
+                args.version_upgrade, print_streams=args.show_output
+            )
+        except NotImplementedError as err:
+            log.error("Distribution version upgrade failed: %s", err)
+            print(str(err), file=sys.stderr)
+            return_code = EXIT.ERR_VM_UPDATE
+    else:
+        log.debug("Running upgrades.")
+        return_code = pkg_mng.upgrade(
+            refresh=not args.no_refresh,
+            hard_fail=not args.force_upgrade,
+            remove_obsolete=not args.leave_obsolete,
+            print_streams=args.show_output,
+        )
 
-    if not pkg_mng.PROGRESS_REPORTING and not args.no_progress:
+    # A version upgrade emits its own 0/100 milestones, so only the normal
+    # update path needs the fallback "finished" tick for CLI managers.
+    if (
+        not args.version_upgrade
+        and not pkg_mng.PROGRESS_REPORTING
+        and not args.no_progress
+    ):
         # even if progress reporting is unavailable we want info that update finished
         if agent_type is AgentType.UPDATE_VM:
             print(f"{55:.2f}", flush=True, file=sys.stderr)

--- a/vmupdate/agent/entrypoint.py
+++ b/vmupdate/agent/entrypoint.py
@@ -40,15 +40,35 @@ def main(args: list[str] | None = None) -> int:
         parsed_args.no_progress,
     )
 
-    log.debug("Running upgrades.")
-    return_code = pkg_mng.upgrade(
-        refresh=not parsed_args.no_refresh,
-        hard_fail=not parsed_args.force_upgrade,
-        remove_obsolete=not parsed_args.leave_obsolete,
-        print_streams=parsed_args.show_output,
-    )
+    if parsed_args.version_upgrade:
+        log.debug(
+            "Running distribution version upgrade to %s.",
+            parsed_args.version_upgrade,
+        )
+        try:
+            return_code = pkg_mng.version_upgrade(
+                parsed_args.version_upgrade,
+                print_streams=parsed_args.show_output,
+            )
+        except NotImplementedError as err:
+            log.error("Distribution version upgrade failed: %s", err)
+            print(str(err), file=sys.stderr)
+            return_code = EXIT.ERR_VM_UPDATE
+    else:
+        log.debug("Running upgrades.")
+        return_code = pkg_mng.upgrade(
+            refresh=not parsed_args.no_refresh,
+            hard_fail=not parsed_args.force_upgrade,
+            remove_obsolete=not parsed_args.leave_obsolete,
+            print_streams=parsed_args.show_output,
+        )
 
-    if not pkg_mng.PROGRESS_REPORTING and not parsed_args.no_progress:
+    # Version upgrades handle their own milestones; this is for normal updates only.
+    if (
+        not parsed_args.version_upgrade
+        and not pkg_mng.PROGRESS_REPORTING
+        and not parsed_args.no_progress
+    ):
         # even if progress reporting is unavailable we want info that update finished
         if agent_type is AgentType.UPDATE_VM:
             print(f"{55:.2f}", flush=True, file=sys.stderr)

--- a/vmupdate/agent/source/apt/apt_api.py
+++ b/vmupdate/agent/source/apt/apt_api.py
@@ -61,10 +61,17 @@ class APT(APTCLI):
         result = ProcessResult()
         try:
             self.log.debug("Refreshing available packages...")
+            # apt.Cache retains the SourceList loaded by open().  Release
+            # upgrades rewrite the source files between refreshes, so reload
+            # them before update(), just as the dnf API release-upgrade path
+            # creates a fresh base for the target release.
+            self.apt_cache.open()
             success = self.apt_cache.update(
                 self.progress.update_progress,
                 pulse_interval=1000,  # microseconds
             )
+            # Reload the package cache again to consume the indexes fetched
+            # by update().
             self.apt_cache.open()
             if success:
                 self.log.debug("Cache refresh successful.")

--- a/vmupdate/agent/source/apt/apt_api.py
+++ b/vmupdate/agent/source/apt/apt_api.py
@@ -90,10 +90,32 @@ class APT(APTCLI):
         """
         Use `apt` package to upgrade and track progress.
         """
+        result = self._api_upgrade(dist_upgrade=remove_obsolete)
+
+        if remove_obsolete:
+            result += self.remove_obsolete_kernels()
+
+        return result
+
+    def _dist_upgrade(self) -> ProcessResult:
+        """
+        API dist-upgrade without APTCLI's obsolete-kernel cleanup, keeping
+        callback-driven progress on the release-upgrade path.
+        """
+        # the release-upgrade step before this one committed a transaction,
+        # which leaves the cache stale; reload before marking changes
+        self.apt_cache.open()
+        return self._api_upgrade(dist_upgrade=True)
+
+    def _api_upgrade(self, dist_upgrade: bool) -> ProcessResult:
+        """
+        Mark an upgrade (or dist-upgrade) in the apt cache and commit it
+        with callback-driven fetch and install progress.
+        """
         result = ProcessResult()
         try:
             self.log.debug("Performing package upgrade...")
-            self.apt_cache.upgrade(dist_upgrade=remove_obsolete)
+            self.apt_cache.upgrade(dist_upgrade=dist_upgrade)
             Path(
                 os.path.join(
                     apt_pkg.config.find_dir("Dir::Cache::Archives"), "partial"
@@ -111,9 +133,6 @@ class APT(APTCLI):
                 "An error occurred while upgrading packages: %s", str(exc)
             )
             result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=str(exc))
-
-        if remove_obsolete:
-            result += self.remove_obsolete_kernels()
 
         return result
 

--- a/vmupdate/agent/source/apt/apt_api.py
+++ b/vmupdate/agent/source/apt/apt_api.py
@@ -31,7 +31,11 @@ import apt_pkg
 from source.common.package_manager import AgentType
 from source.common.process_result import ProcessResult
 from source.common.exit_codes import EXIT
-from source.common.progress_reporter import ProgressReporter, Progress
+from source.common.progress_reporter import (
+    ProgressReporter,
+    Progress,
+    ReleaseUpgradeTail,
+)
 
 from .apt_cli import APTCLI
 
@@ -123,7 +127,15 @@ class APT(APTCLI):
             "APT cache reload before distribution upgrade took %.3fs",
             time.monotonic() - cache_open_started,
         )
-        return self._api_upgrade(dist_upgrade=True)
+        # dpkg still has obsolete-kernel cleanup and qubes.PostInstall
+        # after this commit, so keep the bar off 100. Unlike rpm, apt's own
+        # percent already covers configure and trigger processing, so there
+        # is no scriptlet tail to count here.
+        self.progress.upgrade_progress.open_tail()
+        try:
+            return self._api_upgrade(dist_upgrade=True)
+        finally:
+            self.progress.upgrade_progress.close_tail()
 
     def _api_upgrade(self, dist_upgrade: bool) -> ProcessResult:
         """
@@ -236,16 +248,21 @@ class FetchProgress(apt.progress.base.AcquireProgress, Progress):
         self.notify_callback(100)
 
 
-class UpgradeProgress(apt.progress.base.InstallProgress, Progress):
+class UpgradeProgress(
+    apt.progress.base.InstallProgress, ReleaseUpgradeTail, Progress
+):
     def __init__(self, weight: int, log: Logger) -> None:
         apt.progress.base.InstallProgress.__init__(self)
         Progress.__init__(self, weight, log)
+        # Armed by APT._dist_upgrade() only, so ordinary runs are
+        # unaffected.
+        ReleaseUpgradeTail.__init__(self)
 
     def status_change(self, _pkg: str, percent: float, _status: str) -> None:
         """
         Report ongoing progress on installing/upgrading packages.
         """
-        self.notify_callback(percent)
+        self.notify_callback(self._scaled_percent(percent))
 
     def error(self, pkg: str, errormsg: str) -> None:
         """
@@ -265,4 +282,4 @@ class UpgradeProgress(apt.progress.base.InstallProgress, Progress):
     def finish_update(self) -> None:
         print("Updated.", flush=True)
         super().finish_update()
-        self.notify_callback(100)
+        self.notify_callback(self._scaled_percent(100))

--- a/vmupdate/agent/source/apt/apt_api.py
+++ b/vmupdate/agent/source/apt/apt_api.py
@@ -20,6 +20,7 @@
 # USA.
 
 import os
+import time
 from pathlib import Path
 from logging import Handler, Logger
 
@@ -64,11 +65,26 @@ class APT(APTCLI):
         result = ProcessResult()
         try:
             self.log.debug("Refreshing available packages...")
+            # Reload sources after a release upgrade because apt.Cache retains
+            # the SourceList that open() read.
+            cache_open_started = time.monotonic()
+            self.apt_cache.open()
+            self.log.debug(
+                "APT cache reload before refresh took %.3fs",
+                time.monotonic() - cache_open_started,
+            )
             success = self.apt_cache.update(
                 self.progress.update_progress,
                 pulse_interval=1000,  # microseconds
             )
+            # Reload the package cache again to consume the indexes fetched
+            # by update().
+            cache_open_started = time.monotonic()
             self.apt_cache.open()
+            self.log.debug(
+                "APT cache reload after refresh took %.3fs",
+                time.monotonic() - cache_open_started,
+            )
             if success:
                 self.log.debug("Cache refresh successful.")
             else:
@@ -86,10 +102,45 @@ class APT(APTCLI):
         """
         Use `apt` package to upgrade and track progress.
         """
+        result = self._api_upgrade(dist_upgrade=remove_obsolete)
+
+        if remove_obsolete:
+            result += self.remove_obsolete_kernels()
+
+        return result
+
+    def _dist_upgrade(self) -> ProcessResult:
+        """Run API dist-upgrade with callback progress reporting."""
+        print(
+            "Preparing distribution upgrade; dependency calculation may take "
+            "some time...",
+            flush=True,
+        )
+        # Reload the stale cache before marking distribution changes.
+        cache_open_started = time.monotonic()
+        self.apt_cache.open()
+        self.log.debug(
+            "APT cache reload before distribution upgrade took %.3fs",
+            time.monotonic() - cache_open_started,
+        )
+        return self._api_upgrade(dist_upgrade=True)
+
+    def _api_upgrade(self, dist_upgrade: bool) -> ProcessResult:
+        """
+        Mark an upgrade (or dist-upgrade) in the apt cache and commit it
+        with callback-driven fetch and install progress.
+        """
         result = ProcessResult()
         try:
             self.log.debug("Performing package upgrade...")
-            self.apt_cache.upgrade(dist_upgrade=remove_obsolete)
+            print("Calculating package changes...", flush=True)
+            dependency_started = time.monotonic()
+            self.apt_cache.upgrade(dist_upgrade=dist_upgrade)
+            self.log.debug(
+                "APT dependency calculation (dist_upgrade=%s) took %.3fs",
+                dist_upgrade,
+                time.monotonic() - dependency_started,
+            )
             Path(
                 os.path.join(
                     apt_pkg.config.find_dir("Dir::Cache::Archives"), "partial"
@@ -98,8 +149,13 @@ class APT(APTCLI):
             apt_pkg.config.set("Dpkg::Options::", "--force-confdef")
             apt_pkg.config.set("Dpkg::Options::", "--force-confold")
             self.log.debug("Committing upgrade...")
+            commit_started = time.monotonic()
             self.apt_cache.commit(
                 self.progress.fetch_progress, self.progress.upgrade_progress
+            )
+            self.log.debug(
+                "APT package commit took %.3fs",
+                time.monotonic() - commit_started,
             )
             self.log.debug("Package upgrade successful.")
         except Exception as exc:
@@ -108,17 +164,18 @@ class APT(APTCLI):
             )
             result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=str(exc))
 
-        if remove_obsolete:
-            result += self.remove_obsolete_kernels()
-
         return result
 
 
 class FetchProgress(apt.progress.base.AcquireProgress, Progress):
+    # Report fetch progress while apt provides no percentage.
+    REPORT_INTERVAL = 30
+
     def __init__(self, weight: int, log: Logger, refresh: bool = False) -> None:
         Progress.__init__(self, weight, log)
         self.action = "refresh" if refresh else "fetch"
         self.fetching_notified = False
+        self._last_report = 0.0
 
     def fail(self, item: apt_pkg.AcquireItemDesc) -> None:
         """
@@ -140,6 +197,7 @@ class FetchProgress(apt.progress.base.AcquireProgress, Progress):
         This function returns a boolean value indicating whether the
         acquisition should be continued (True) or cancelled (False).
         """
+        now = time.monotonic()
         if self.action == "fetch" and not self.fetching_notified:
             print(
                 f"Fetching {self.total_items} packages "
@@ -147,12 +205,24 @@ class FetchProgress(apt.progress.base.AcquireProgress, Progress):
                 flush=True,
             )
             self.fetching_notified = True
+            self._last_report = now
+        elif now - self._last_report >= self.REPORT_INTERVAL:
+            print(
+                f"{self.action.capitalize()}ing "
+                f"{self._format_bytes(self.current_bytes)} of "
+                f"{self._format_bytes(self.total_bytes)}...",
+                flush=True,
+            )
+            self._last_report = now
         self.notify_callback(self.current_bytes / self.total_bytes * 100)
         return True
 
     def start(self) -> None:
         """Invoked when the Acquire process starts running."""
         self.log.info(f"{self.action.capitalize()} started.")
+        # Re-arm the fetch notice for each acquire run.
+        self.fetching_notified = False
+        self._last_report = time.monotonic()
         if self.action == "refresh":
             print("Refreshing available packages.", flush=True)
         super().start()

--- a/vmupdate/agent/source/apt/apt_cli.py
+++ b/vmupdate/agent/source/apt/apt_cli.py
@@ -21,11 +21,12 @@
 
 # pylint: disable=unused-argument
 
+import csv
 import fcntl
 import glob
 import os
 import contextlib
-from typing import List
+from typing import List, Optional
 
 from source.utils import get_os_data
 from source.common.package_manager import PackageManager, AgentType
@@ -36,14 +37,9 @@ from source.common.exit_codes import EXIT
 class APTCLI(PackageManager):
     PROGRESS_REPORTING = False
 
-    # apt addresses releases by codename, but the tool speaks release
-    # numbers; extend as new releases appear
-    DEBIAN_CODENAMES = {
-        11: "bullseye",
-        12: "bookworm",
-        13: "trixie",
-        14: "forky",
-    }
+    # Maintained by Debian's distro-info-data package, which is a
+    # qubes-core-agent dependency (including in minimal templates).
+    DEBIAN_RELEASES_FILE = "/usr/share/distro-info/debian.csv"
 
     # Every apt source definition that can name a release codename, in both
     # the one-line (`.list`) and deb822 (`.sources`) formats.
@@ -210,7 +206,18 @@ class APTCLI(PackageManager):
             return guard
 
         old_codename = os_data["codename"]
-        new_codename = self.DEBIAN_CODENAMES[int(target)]
+        try:
+            new_codename = self._debian_codename(target)
+        except (OSError, csv.Error) as exc:
+            return self._refuse(
+                f"cannot read Debian release data from "
+                f"{self.DEBIAN_RELEASES_FILE}: {exc}."
+            )
+        if not new_codename:
+            return self._refuse(
+                f"no Debian codename for release {target!r} in "
+                f"{self.DEBIAN_RELEASES_FILE}."
+            )
 
         self._report_progress(0.0)
         result = ProcessResult()
@@ -280,14 +287,8 @@ class APTCLI(PackageManager):
         self, target: str, os_data: dict
     ) -> ProcessResult:
         """
-        The shared single-step check plus Debian specifics: the in-qube
-        family must be Debian and both codenames must be known.
+        The shared single-step check plus the current Debian codename check.
         """
-        if os_data.get("os_family") != "Debian":
-            return self._refuse(
-                f"in-qube OS family {os_data.get('os_family')!r} is not Debian."
-            )
-
         result = super()._verify_release_upgrade(target, os_data)
         if result.code:
             return result
@@ -296,13 +297,22 @@ class APTCLI(PackageManager):
             return self._refuse(
                 "cannot read the in-qube release codename from os-release."
             )
-        if int(target) not in self.DEBIAN_CODENAMES:
-            return self._refuse(
-                f"no known Debian codename for release {target!r}; "
-                "extend DEBIAN_CODENAMES in apt_cli.py."
-            )
 
         return ProcessResult()
+
+    @classmethod
+    def _debian_codename(cls, target: str) -> Optional[str]:
+        """Return Debian's codename for a numeric release."""
+        with open(
+            cls.DEBIAN_RELEASES_FILE,
+            "r",
+            encoding="utf-8",
+            newline="",
+        ) as releases_file:
+            for release in csv.DictReader(releases_file):
+                if release.get("version") == target:
+                    return release.get("series") or None
+        return None
 
     def _rewrite_sources(
         self, old_codename: str, new_codename: str
@@ -351,7 +361,7 @@ class APTCLI(PackageManager):
             return ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=msg)
         if not changed:
             return self._refuse(
-                f"no apt source references codename {old_codename!r}; refusing "
-                "to report a release upgrade that would not actually happen."
+                f"no apt source references codename {old_codename!r}; "
+                "refusing upgrade."
             )
         return ProcessResult()

--- a/vmupdate/agent/source/apt/apt_cli.py
+++ b/vmupdate/agent/source/apt/apt_cli.py
@@ -22,10 +22,12 @@
 # pylint: disable=unused-argument
 
 import fcntl
+import glob
 import os
 import contextlib
 from typing import List
 
+from source.utils import get_os_data
 from source.common.package_manager import PackageManager, AgentType
 from source.common.process_result import ProcessResult
 from source.common.exit_codes import EXIT
@@ -33,6 +35,23 @@ from source.common.exit_codes import EXIT
 
 class APTCLI(PackageManager):
     PROGRESS_REPORTING = False
+
+    # apt addresses releases by codename, but the tool speaks release
+    # numbers; extend as new releases appear
+    DEBIAN_CODENAMES = {
+        11: "bullseye",
+        12: "bookworm",
+        13: "trixie",
+        14: "forky",
+    }
+
+    # Every apt source definition that can name a release codename, in both
+    # the one-line (`.list`) and deb822 (`.sources`) formats.
+    APT_SOURCE_GLOBS = (
+        "/etc/apt/sources.list",
+        "/etc/apt/sources.list.d/*.list",
+        "/etc/apt/sources.list.d/*.sources",
+    )
 
     def __init__(self, log_handler, log_level, agent_type: AgentType):
         super().__init__(log_handler, log_level, agent_type)
@@ -173,3 +192,166 @@ class APTCLI(PackageManager):
 
         result.code = EXIT.ERR_VM_CLEANUP if result.code != 0 else 0
         return result
+
+    def _release_upgrade(self, target_version: str) -> ProcessResult:
+        """
+        Move the qube to the next Debian release.
+
+        apt addresses releases by codename (unlike dnf's ``--releasever``),
+        so after bringing the current release fully up to date we rewrite
+        the codename across all apt sources, then ``update`` +
+        ``dist-upgrade`` onto the new release.
+        """
+        target = str(target_version).strip()
+        os_data = get_os_data(self.log)
+
+        guard = self._verify_release_upgrade(target, os_data)
+        if guard.code:
+            return guard
+
+        old_codename = os_data["codename"]
+        new_codename = self.DEBIAN_CODENAMES[int(target)]
+
+        self._report_progress(0.0)
+        result = ProcessResult()
+
+        # bring the current release fully up to date, point the sources at
+        # the new release, then update + dist-upgrade onto it; a stale
+        # system risks unresolvable transactions across the boundary
+        steps = (
+            lambda: self.refresh(hard_fail=True),
+            lambda: self.upgrade_internal(remove_obsolete=False),
+            lambda: self._rewrite_sources(old_codename, new_codename),
+            lambda: self.refresh(hard_fail=True),
+            lambda: self.upgrade_internal(remove_obsolete=False),
+            self._dist_upgrade,
+        )
+        for step in steps:
+            step_result = step()
+            result += step_result
+            if step_result.code:
+                result.code = EXIT.ERR_VM_UPDATE
+                return result
+
+        try:
+            upgraded_os_data = get_os_data(self.log)
+        except OSError as exc:
+            msg = f"failed to verify the upgraded Debian release: {exc}"
+            self.log.error(msg)
+            result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=msg)
+            return result
+
+        upgraded_release = upgraded_os_data.get("release", "").split(".")[0]
+        upgraded_codename = upgraded_os_data.get("codename", "")
+        if upgraded_release != target or upgraded_codename != new_codename:
+            msg = (
+                f"Debian release upgrade did not reach {target} "
+                f"({new_codename}); os-release reports "
+                f"{upgraded_os_data.get('release')!r} "
+                f"({upgraded_codename or 'no codename'})."
+            )
+            self.log.error(msg)
+            result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=msg)
+            return result
+
+        # old kernels are heavy but non-critical: a cleanup failure must not
+        # discard a template that actually reached the new release
+        cleanup = self.remove_obsolete_kernels()
+        result += cleanup
+        if cleanup.code:
+            self.log.warning(
+                "post-upgrade obsolete-kernel cleanup failed (non-fatal): %s",
+                cleanup.err,
+            )
+        result.code = EXIT.OK
+
+        self._report_progress(100.0)
+        return result
+
+    def _dist_upgrade(self) -> ProcessResult:
+        """
+        Plain `apt-get dist-upgrade`, without APTCLI's obsolete-kernel
+        cleanup, so the fatal release bump and the best-effort cleanup
+        can fail independently.
+        """
+        return PackageManager.upgrade_internal(self, remove_obsolete=True)
+
+    def _verify_release_upgrade(
+        self, target: str, os_data: dict
+    ) -> ProcessResult:
+        """
+        The shared single-step check plus Debian specifics: the in-qube
+        family must be Debian and both codenames must be known.
+        """
+        if os_data.get("os_family") != "Debian":
+            return self._refuse(
+                f"in-qube OS family {os_data.get('os_family')!r} is not Debian."
+            )
+
+        result = super()._verify_release_upgrade(target, os_data)
+        if result.code:
+            return result
+
+        if not os_data.get("codename"):
+            return self._refuse(
+                "cannot read the in-qube release codename from os-release."
+            )
+        if int(target) not in self.DEBIAN_CODENAMES:
+            return self._refuse(
+                f"no known Debian codename for release {target!r}; "
+                "extend DEBIAN_CODENAMES in apt_cli.py."
+            )
+
+        return ProcessResult()
+
+    def _rewrite_sources(
+        self, old_codename: str, new_codename: str
+    ) -> ProcessResult:
+        """
+        Substring-replace the old codename with the new across every apt
+        source file, covering ``-security``/``-updates``/``-backports``
+        variants in both the one-line and deb822 formats. Missing files are
+        skipped; I/O errors abort.
+
+        Refuses if no file mentioned the old codename: such sources address
+        the release symbolically (e.g. ``stable``), the rewrite would be a
+        no-op and the qube would silently stay on the old release.
+
+        The plain substring replace matches the manual ``sed`` procedure in
+        qubes-doc; switch to per-field deb822 parsing if it ever over-matches.
+        """
+        changed = 0
+        try:
+            for pattern in self.APT_SOURCE_GLOBS:
+                for path in glob.glob(pattern):
+                    with open(path, "r", encoding="utf-8") as f_src:
+                        content = f_src.read()
+                    updated = content.replace(old_codename, new_codename)
+                    if updated == content:
+                        continue  # no codename here -> no spurious write
+                    # write-then-rename so a mid-write kill cannot leave a
+                    # truncated sources file behind (apt would treat an
+                    # empty sources list as "nothing to do" and succeed)
+                    tmp_path = path + ".tmp"
+                    with open(tmp_path, "w", encoding="utf-8") as f_src:
+                        f_src.write(updated)
+                        f_src.flush()
+                        os.fsync(f_src.fileno())
+                    os.replace(tmp_path, path)
+                    changed += 1
+                    self.log.info(
+                        "Rewrote apt source %s: %s -> %s",
+                        path,
+                        old_codename,
+                        new_codename,
+                    )
+        except OSError as exc:
+            msg = f"failed rewriting apt sources: {exc}"
+            self.log.error(msg)
+            return ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=msg)
+        if not changed:
+            return self._refuse(
+                f"no apt source references codename {old_codename!r}; refusing "
+                "to report a release upgrade that would not actually happen."
+            )
+        return ProcessResult()

--- a/vmupdate/agent/source/apt/apt_cli.py
+++ b/vmupdate/agent/source/apt/apt_cli.py
@@ -21,12 +21,15 @@
 
 # pylint: disable=unused-argument
 
+import csv
 import fcntl
+import glob
 import os
 import contextlib
-from typing import List, Iterator
+from typing import List, Iterator, Optional
 from logging import Handler
 
+from source.utils import get_os_data
 from source.common.package_manager import PackageManager, AgentType
 from source.common.process_result import ProcessResult
 from source.common.exit_codes import EXIT
@@ -34,6 +37,17 @@ from source.common.exit_codes import EXIT
 
 class APTCLI(PackageManager):
     PROGRESS_REPORTING = False
+
+    # Maintained by Debian's distro-info-data package, which is a
+    # qubes-core-agent dependency (including in minimal templates).
+    DEBIAN_RELEASES_FILE = "/usr/share/distro-info/debian.csv"
+
+    # APT source files in one-line (.list) and deb822 (.sources) formats.
+    APT_SOURCE_GLOBS = (
+        "/etc/apt/sources.list",
+        "/etc/apt/sources.list.d/*.list",
+        "/etc/apt/sources.list.d/*.sources",
+    )
 
     def __init__(
         self, log_handler: Handler, log_level: int, agent_type: AgentType
@@ -176,3 +190,192 @@ class APTCLI(PackageManager):
 
         result.code = EXIT.ERR_VM_CLEANUP if result.code != 0 else 0
         return result
+
+    def _release_upgrade(self, target_version: str) -> ProcessResult:
+        """Upgrade to the target Debian release by rewriting apt source codenames and running dist-upgrade."""
+        target = str(target_version).strip()
+        os_data = get_os_data(self.log)
+
+        guard = self._verify_release_upgrade(target, os_data)
+        if guard.code:
+            return guard
+
+        old_codename = os_data["codename"]
+        try:
+            new_codename = self._debian_codename(target)
+        except (OSError, csv.Error) as exc:
+            return self._refuse(
+                f"cannot read Debian release data from "
+                f"{self.DEBIAN_RELEASES_FILE}: {exc}."
+            )
+        if not new_codename:
+            return self._refuse(
+                f"no Debian codename for release {target!r} in "
+                f"{self.DEBIAN_RELEASES_FILE}."
+            )
+
+        # Refuse early if no source file references the old or new codename.
+        try:
+            sources = [
+                open(path, "r", encoding="utf-8").read()
+                for path in self._apt_source_paths()
+            ]
+        except OSError as exc:
+            return self._refuse(f"cannot read apt sources: {exc}.")
+        if not any(
+            old_codename in content or new_codename in content
+            for content in sources
+        ):
+            return self._refuse(
+                f"no apt source references codename {old_codename!r} "
+                f"or {new_codename!r}; refusing upgrade."
+            )
+
+        self._report_progress(0.0)
+        result = ProcessResult()
+
+        # Update before switching sources and running dist-upgrade: a stale
+        # system risks unresolvable transactions across the release boundary.
+        steps = (
+            lambda: self.refresh(hard_fail=True),
+            lambda: self.upgrade_internal(remove_obsolete=False),
+            lambda: self._rewrite_sources(old_codename, new_codename),
+            lambda: self.refresh(hard_fail=True),
+            lambda: self.upgrade_internal(remove_obsolete=False),
+            self._dist_upgrade,
+        )
+        for step in steps:
+            step_result = step()
+            result += step_result
+            if step_result.code:
+                result.code = EXIT.ERR_VM_UPDATE
+                return result
+
+        try:
+            upgraded_os_data = get_os_data(self.log)
+        except OSError as exc:
+            msg = f"failed to verify the upgraded Debian release: {exc}"
+            self.log.error(msg)
+            result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=msg)
+            return result
+
+        upgraded_release = upgraded_os_data.get("release", "").split(".")[0]
+        upgraded_codename = upgraded_os_data.get("codename", "")
+        if upgraded_release != target or upgraded_codename != new_codename:
+            msg = (
+                f"Debian release upgrade did not reach {target} "
+                f"({new_codename}); os-release reports "
+                f"{upgraded_os_data.get('release')!r} "
+                f"({upgraded_codename or 'no codename'})."
+            )
+            self.log.error(msg)
+            result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=msg)
+            return result
+
+        # Kernel cleanup failure must not discard a completed upgrade.
+        cleanup = self.remove_obsolete_kernels()
+        result += cleanup
+        if cleanup.code:
+            self.log.warning(
+                "post-upgrade obsolete-kernel cleanup failed (non-fatal): %s",
+                cleanup.err,
+            )
+        result.code = EXIT.OK
+
+        self._finish_progress()
+        return result
+
+    def _dist_upgrade(self) -> ProcessResult:
+        """Run dist-upgrade without kernel cleanup so failures are independent."""
+        return PackageManager.upgrade_internal(self, remove_obsolete=True)
+
+    def _verify_release_upgrade(
+        self, target: str, os_data: dict
+    ) -> ProcessResult:
+        """
+        The shared single-step check plus the current Debian codename check.
+        """
+        result = super()._verify_release_upgrade(target, os_data)
+        if result.code:
+            return result
+
+        if not os_data.get("codename"):
+            return self._refuse(
+                "cannot read the in-qube release codename from os-release."
+            )
+
+        return ProcessResult()
+
+    @classmethod
+    def _debian_codename(cls, target: str) -> Optional[str]:
+        """Return Debian's codename for a numeric release."""
+        with open(
+            cls.DEBIAN_RELEASES_FILE,
+            "r",
+            encoding="utf-8",
+            newline="",
+        ) as releases_file:
+            for release in csv.DictReader(releases_file):
+                if release.get("version") == target:
+                    if not release.get("release"):
+                        # distro-info lists unreleased versions too;
+                        # not a released Debian yet, so no codename.
+                        return None
+                    return release.get("series") or None
+        return None
+
+    @classmethod
+    def _apt_source_paths(cls) -> List[str]:
+        """Every existing apt source file matched by APT_SOURCE_GLOBS."""
+        return [
+            path
+            for pattern in cls.APT_SOURCE_GLOBS
+            for path in glob.glob(pattern)
+        ]
+
+    def _rewrite_sources(
+        self, old_codename: str, new_codename: str
+    ) -> ProcessResult:
+        """Replace the old release codename with the new one in all apt source files.
+
+        Refuses if no source references either codename (e.g. symbolic 'stable' sources).
+        """
+        changed = 0
+        try:
+            for path in self._apt_source_paths():
+                with open(path, "r", encoding="utf-8") as f_src:
+                    content = f_src.read()
+                updated = content.replace(old_codename, new_codename)
+                if updated == content:
+                    if new_codename in content:
+                        # Already rewritten by an interrupted run.
+                        changed += 1
+                    continue  # no codename here -> no spurious write
+                # Atomic write: preserve symlinks, permissions, and ownership.
+                real_path = os.path.realpath(path)
+                st = os.stat(real_path)
+                tmp_path = real_path + ".tmp"
+                with open(tmp_path, "w", encoding="utf-8") as f_src:
+                    f_src.write(updated)
+                    f_src.flush()
+                    os.fsync(f_src.fileno())
+                os.chmod(tmp_path, st.st_mode)
+                os.chown(tmp_path, st.st_uid, st.st_gid)
+                os.replace(tmp_path, real_path)
+                changed += 1
+                self.log.info(
+                    "Rewrote apt source %s: %s -> %s",
+                    path,
+                    old_codename,
+                    new_codename,
+                )
+        except OSError as exc:
+            msg = f"failed rewriting apt sources: {exc}"
+            self.log.error(msg)
+            return ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=msg)
+        if not changed:
+            return self._refuse(
+                f"no apt source references codename {old_codename!r}; "
+                "refusing upgrade."
+            )
+        return ProcessResult()

--- a/vmupdate/agent/source/apt/apt_cli.py
+++ b/vmupdate/agent/source/apt/apt_cli.py
@@ -240,15 +240,31 @@ class APTCLI(PackageManager):
 
         # Update before switching sources and running dist-upgrade: a stale
         # system risks unresolvable transactions across the release boundary.
+        # Each step gets its own slice of the bar, weighted by its share of
+        # a measured debian-12 to 13 template upgrade; without that, every
+        # step drives the same three-phase reporter to 100 in turn.
+        # (bar weight, drives fetch/install phases, step)
         steps = (
-            lambda: self.refresh(hard_fail=True),
-            lambda: self.upgrade_internal(remove_obsolete=False),
-            lambda: self._rewrite_sources(old_codename, new_codename),
-            lambda: self.refresh(hard_fail=True),
-            lambda: self.upgrade_internal(remove_obsolete=False),
-            self._dist_upgrade,
+            (7, False, lambda: self.refresh(hard_fail=True)),
+            (7, True, lambda: self.upgrade_internal(remove_obsolete=False)),
+            (
+                1,
+                False,
+                lambda: self._rewrite_sources(old_codename, new_codename),
+            ),
+            (9, False, lambda: self.refresh(hard_fail=True)),
+            (22, True, lambda: self.upgrade_internal(remove_obsolete=False)),
+            (54, True, self._dist_upgrade),
         )
-        for step in steps:
+        total = sum(weight for weight, _, _ in steps)
+        done = 0
+        for weight, installs, step in steps:
+            self._set_progress_step(
+                done / total * RELEASE_UPGRADE_ALMOST_DONE,
+                (done + weight) / total * RELEASE_UPGRADE_ALMOST_DONE,
+                installs,
+            )
+            done += weight
             step_result = step()
             result += step_result
             if step_result.code:

--- a/vmupdate/agent/source/apt/apt_cli.py
+++ b/vmupdate/agent/source/apt/apt_cli.py
@@ -30,7 +30,11 @@ from typing import List, Iterator, Optional
 from logging import Handler
 
 from source.utils import get_os_data
-from source.common.package_manager import PackageManager, AgentType
+from source.common.package_manager import (
+    PackageManager,
+    AgentType,
+    RELEASE_UPGRADE_ALMOST_DONE,
+)
 from source.common.process_result import ProcessResult
 from source.common.exit_codes import EXIT
 
@@ -282,7 +286,8 @@ class APTCLI(PackageManager):
             )
         result.code = EXIT.OK
 
-        self._finish_progress()
+        # version_upgrade() owns the jump to 100, after qubes.PostInstall.
+        self._report_milestone(RELEASE_UPGRADE_ALMOST_DONE)
         return result
 
     def _dist_upgrade(self) -> ProcessResult:

--- a/vmupdate/agent/source/args.py
+++ b/vmupdate/agent/source/args.py
@@ -51,6 +51,13 @@ class AgentArgs:
             "action": "store_true",
             "help": "Only download packages",
         },
+        ("--version-upgrade",): {
+            "action": "store",
+            "default": None,
+            "help": "Upgrade the distribution to the given next major "
+            "release, e.g. --version-upgrade 42. Without this flag a "
+            "normal same-release package update is performed.",
+        },
     }
     EXCLUSIVE_OPTIONS_1 = {
         ("--show-output", "--verbose", "-v"): {
@@ -104,5 +111,10 @@ class AgentArgs:
                 if args_dict[param_name]:
                     cli_args.append(keys[0])
             else:
-                cli_args.extend((keys[0], args_dict[param_name]))
+                # Value-bearing options default to None when unset (e.g.
+                # --version-upgrade on a normal update). Skip those so we
+                # never inject a bare "None" into the agent command line.
+                arg_value = args_dict[param_name]
+                if arg_value is not None:
+                    cli_args.extend((keys[0], str(arg_value)))
         return cli_args

--- a/vmupdate/agent/source/args.py
+++ b/vmupdate/agent/source/args.py
@@ -19,13 +19,13 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
 # USA.
 import argparse
+from typing import Any
 
 
 class AgentArgs:
     # To avoid code repeating when we want to retrieve arguments
-    OPTIONS: dict[
-        tuple[str] | tuple[str, str] | tuple[str, str, str], dict[str, str]
-    ] = {
+    # Values are heterogeneous: "default" may be None, so not just str.
+    OPTIONS: dict[tuple, dict[str, Any]] = {
         ("--log",): {
             "action": "store",
             "default": "INFO",
@@ -53,6 +53,13 @@ class AgentArgs:
             "action": "store_true",
             "help": "Only download packages",
         },
+        # Hidden: only qvm-template-upgrade may drive an in-place
+        # release upgrade; qubes-vm-update rejects it in parse_args.
+        ("--version-upgrade",): {
+            "action": "store",
+            "default": None,
+            "help": argparse.SUPPRESS,
+        },
     }
     EXCLUSIVE_OPTIONS_1: dict[
         tuple[str] | tuple[str, str] | tuple[str, str, str], dict[str, str]
@@ -78,9 +85,7 @@ class AgentArgs:
             "help": argparse.SUPPRESS,
         },
     }
-    ALL_OPTIONS: dict[
-        tuple[str] | tuple[str, str] | tuple[str, str, str], dict[str, str]
-    ] = {
+    ALL_OPTIONS: dict[tuple, dict[str, Any]] = {
         **OPTIONS,
         **EXCLUSIVE_OPTIONS_1,
         **EXCLUSIVE_OPTIONS_2,
@@ -116,5 +121,10 @@ class AgentArgs:
                 if args_dict[param_name]:
                     cli_args.append(keys[0])
             else:
-                cli_args.extend((keys[0], args_dict[param_name]))
+                # Value-bearing options default to None when unset (e.g.
+                # --version-upgrade on a normal update). Skip those so we
+                # never inject a bare "None" into the agent command line.
+                arg_value = args_dict[param_name]
+                if arg_value is not None:
+                    cli_args.extend((keys[0], str(arg_value)))
         return cli_args

--- a/vmupdate/agent/source/common/package_manager.py
+++ b/vmupdate/agent/source/common/package_manager.py
@@ -78,6 +78,33 @@ class PackageManager:
                 print(result.err, file=sys.stderr, flush=True)
         return result.code
 
+    def version_upgrade(
+        self,
+        target_version: str,
+        print_streams: bool = False,
+    ) -> int:
+        """
+        Upgrade the distribution to the next major release.
+
+        Separate from `upgrade`, which only refreshes packages within the
+        current release. The family-specific work lives in
+        `_release_upgrade`.
+
+        :param target_version: the major release to move to, e.g. "42"
+        :param print_streams: dump captured output to std streams
+        :return: return code (0 on success)
+        """
+        result = self._release_upgrade(target_version)
+        self._log_output("version-upgrade", result)
+        # Logs are for the agent log; print_streams is only CLI passthrough.
+        # Avoid printing again when the subprocess already streamed live.
+        if print_streams and not result.posted:
+            if result.out:
+                print(result.out, flush=True)
+            if result.err:
+                print(result.err, file=sys.stderr, flush=True)
+        return result.code
+
     def _upgrade(
         self,
         refresh: bool,
@@ -311,6 +338,23 @@ class PackageManager:
         cmd = [self.package_manager, *self.get_action(remove_obsolete)]
 
         return self.run_cmd(cmd)
+
+    def _release_upgrade(self, target_version: str) -> ProcessResult:
+        """
+        Perform a distribution release upgrade.
+
+        Overridden per package-manager family. The default raises
+        NotImplementedError; callers (e.g. entrypoint.main) catch it and
+        decide how to report the unsupported path.
+        """
+        raise self._missing_release_upgrade_error()
+
+    def _missing_release_upgrade_error(self) -> NotImplementedError:
+        """Build the error used when a family has no release upgrade."""
+        return NotImplementedError(
+            "Distribution version upgrade is not implemented for this "
+            f"package manager ({self.package_manager})."
+        )
 
     def clean(self) -> int:
         """

--- a/vmupdate/agent/source/common/package_manager.py
+++ b/vmupdate/agent/source/common/package_manager.py
@@ -347,14 +347,51 @@ class PackageManager:
         NotImplementedError; callers (e.g. entrypoint.main) catch it and
         decide how to report the unsupported path.
         """
-        raise self._missing_release_upgrade_error()
-
-    def _missing_release_upgrade_error(self) -> NotImplementedError:
-        """Build the error used when a family has no release upgrade."""
-        return NotImplementedError(
+        raise NotImplementedError(
             "Distribution version upgrade is not implemented for this "
             f"package manager ({self.package_manager})."
         )
+
+    def _verify_release_upgrade(
+        self, target: str, os_data: dict
+    ) -> ProcessResult:
+        """
+        Refuse (errored ProcessResult) unless ``target`` is a plain release
+        number exactly one above the in-qube major release. dom0 derives the
+        target from qvm-features that can drift, hence this in-qube re-check
+        before anything irreversible. Families extend it with their own
+        checks.
+        """
+        if not target.isdigit():
+            return self._refuse(f"invalid target release {target!r}.")
+
+        current_major = os_data.get("release", "").split(".")[0]
+        if not current_major.isdigit():
+            return self._refuse(
+                f"cannot read a numeric in-qube release from "
+                f"{os_data.get('release')!r}."
+            )
+        if int(target) != int(current_major) + 1:
+            return self._refuse(
+                f"in-qube release {os_data.get('release')!r} can only move "
+                f"to {int(current_major) + 1} (single step), not {target!r}."
+            )
+
+        return ProcessResult()
+
+    def _refuse(self, reason: str) -> ProcessResult:
+        """Log and build the standard "refusing version upgrade" error."""
+        msg = f"Refusing version upgrade: {reason}"
+        self.log.error(msg)
+        return ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=msg)
+
+    @staticmethod
+    def _report_progress(percent: float) -> None:
+        """
+        Emit a progress milestone: a bare float per line on stderr, parsed
+        by dom0's QubeConnection. 100.0 signals completion.
+        """
+        print(f"{percent:.2f}", flush=True, file=sys.stderr)
 
     def clean(self) -> int:
         """

--- a/vmupdate/agent/source/common/package_manager.py
+++ b/vmupdate/agent/source/common/package_manager.py
@@ -28,6 +28,10 @@ import enum
 from typing import Optional, Dict, List, Any
 from .process_result import ProcessResult
 from .exit_codes import EXIT
+from .progress_reporter import ReleaseUpgradeTail
+
+# Where a release upgrade leaves the bar before qubes.PostInstall runs.
+RELEASE_UPGRADE_ALMOST_DONE = ReleaseUpgradeTail.TAIL_STOP
 
 
 class AgentType(enum.Enum):
@@ -110,6 +114,10 @@ class PackageManager:
                     "(qvm-features) will refresh on next qube start.",
                     postinstall,
                 )
+        if result.code == EXIT.OK:
+            # After qubes.PostInstall, whose fstrim runs long enough that
+            # reporting 100 first leaves the bar apparently stuck.
+            self._finish_progress()
         self._log_output("version-upgrade", result)
         # Do not duplicate output that already streamed live.
         if print_streams and not result.posted:
@@ -399,16 +407,20 @@ class PackageManager:
         """
         print(f"{percent:.2f}", flush=True, file=sys.stderr)
 
-    def _finish_progress(self) -> None:
-        """Report completion unless callback progress already reached 100.
-
-        dom0 reads everything after the first 100 as error text, so a second
-        one surfaces as a bogus "err: 100.00" line.
+    def _report_milestone(self, percent: float) -> None:
+        """
+        Report `percent` unless callback progress already passed it.
         """
         progress = getattr(self, "progress", None)
-        if progress is not None and progress.last_percent >= 100:
-            return
-        self._report_progress(100.0)
+        if progress is not None:
+            if progress.last_percent >= percent:
+                return
+            progress.last_percent = percent
+        self._report_progress(percent)
+
+    def _finish_progress(self) -> None:
+        """Report 100% completion if not already reported."""
+        self._report_milestone(100.0)
 
     def clean(self) -> int:
         """

--- a/vmupdate/agent/source/common/package_manager.py
+++ b/vmupdate/agent/source/common/package_manager.py
@@ -407,6 +407,16 @@ class PackageManager:
         """
         print(f"{percent:.2f}", flush=True, file=sys.stderr)
 
+    def _set_progress_step(
+        self, start: float, stop: float, installs: bool
+    ) -> None:
+        """
+        Claim `start`..`stop` for the next step, if the backend reports.
+        """
+        progress = getattr(self, "progress", None)
+        if progress is not None:
+            progress.set_step_range(start, stop, installs)
+
     def _report_milestone(self, percent: float) -> None:
         """
         Report `percent` unless callback progress already passed it.

--- a/vmupdate/agent/source/common/package_manager.py
+++ b/vmupdate/agent/source/common/package_manager.py
@@ -83,6 +83,42 @@ class PackageManager:
                 print(result.err, file=sys.stderr, flush=True)
         return result.code
 
+    def version_upgrade(
+        self,
+        target_version: str,
+        print_streams: bool = False,
+    ) -> int:
+        """Upgrade to the next major release.
+
+        Backends implement the family-specific work.
+        """
+        result = self._release_upgrade(target_version)
+        if result.code == EXIT.OK and self.type is AgentType.VM:
+            # Refresh dom0 metadata after a successful VM release upgrade.
+            # Warn only if the refresh fails.
+            self.log.info("Notifying dom0 about the new release")
+            try:
+                postinstall = subprocess.call(
+                    ["/etc/qubes-rpc/qubes.PostInstall"]
+                )
+            except OSError as exc:
+                postinstall = -1
+                self.log.warning("could not run qubes.PostInstall: %s", exc)
+            if postinstall != 0:
+                self.log.warning(
+                    "qubes.PostInstall exited with %d; dom0 metadata "
+                    "(qvm-features) will refresh on next qube start.",
+                    postinstall,
+                )
+        self._log_output("version-upgrade", result)
+        # Do not duplicate output that already streamed live.
+        if print_streams and not result.posted:
+            if result.out:
+                print(result.out, flush=True)
+            if result.err:
+                print(result.err, file=sys.stderr, flush=True)
+        return result.code
+
     def _upgrade(
         self,
         refresh: bool,
@@ -320,6 +356,59 @@ class PackageManager:
         cmd = [self.package_manager, *self.get_action(remove_obsolete)]
 
         return self.run_cmd(cmd)
+
+    def _release_upgrade(self, target_version: str) -> ProcessResult:
+        """Perform a distribution release upgrade. Must be overridden by subclasses."""
+        raise NotImplementedError(
+            "Distribution version upgrade is not implemented for this "
+            f"package manager ({self.package_manager})."
+        )
+
+    def _verify_release_upgrade(
+        self, target: str, os_data: dict
+    ) -> ProcessResult:
+        """Verify the target is a valid single-step upgrade from the current release."""
+        if not (target.isascii() and target.isdigit()):
+            return self._refuse(f"invalid target release {target!r}.")
+
+        current_major = os_data.get("release", "").split(".")[0]
+        if not (current_major.isascii() and current_major.isdigit()):
+            return self._refuse(
+                f"cannot read a numeric in-qube release from "
+                f"{os_data.get('release')!r}."
+            )
+        if int(target) != int(current_major) + 1:
+            return self._refuse(
+                f"in-qube release {os_data.get('release')!r} can only move "
+                f"to {int(current_major) + 1} (single step), not {target!r}."
+            )
+
+        return ProcessResult()
+
+    def _refuse(self, reason: str) -> ProcessResult:
+        """Log and build the standard "refusing version upgrade" error."""
+        msg = f"Refusing version upgrade: {reason}"
+        self.log.error(msg)
+        return ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=msg)
+
+    @staticmethod
+    def _report_progress(percent: float) -> None:
+        """Emit a progress percentage for dom0.
+
+        A bare float per line on stderr, parsed by dom0's QubeConnection.
+        """
+        print(f"{percent:.2f}", flush=True, file=sys.stderr)
+
+    def _finish_progress(self) -> None:
+        """Report completion unless callback progress already reached 100.
+
+        dom0 reads everything after the first 100 as error text, so a second
+        one surfaces as a bogus "err: 100.00" line.
+        """
+        progress = getattr(self, "progress", None)
+        if progress is not None and progress.last_percent >= 100:
+            return
+        self._report_progress(100.0)
 
     def clean(self) -> int:
         """

--- a/vmupdate/agent/source/common/progress_reporter.py
+++ b/vmupdate/agent/source/common/progress_reporter.py
@@ -105,11 +105,20 @@ class ProgressReporter:
         self.stderr = io.TextIOWrapper(os.fdopen(saved_stderr, "wb"))
         self.last_percent = 0.0
         if callback is None:
-            self.callback = lambda p: print(
+            emit: Callable[[float], None] = lambda p: print(
                 f"{p:.2f}", flush=True, file=self.stderr
             )
         else:
-            self.callback = callback
+            emit = callback
+
+        def callback_with_memory(percent: float) -> None:
+            # Remember the highest value reported so far, so callers can
+            # tell whether the stream already reached 100 and skip a
+            # duplicate final milestone (PackageManager._finish_progress).
+            self.last_percent = max(self.last_percent, percent)
+            emit(percent)
+
+        self.callback = callback_with_memory
 
         total = update.weight + fetch.weight + upgrade.weight
         update_end = update.weight / total * 100

--- a/vmupdate/agent/source/common/progress_reporter.py
+++ b/vmupdate/agent/source/common/progress_reporter.py
@@ -144,7 +144,10 @@ class ReleaseUpgradeTail:
 
     def _local_for_overall(self, overall: float) -> float:
         """
-        Convert an overall-bar percent into this phase's local percent.
+        Convert a reporter-scale percent into this phase's local percent.
+
+        ProgressReporter.set_step_range() may narrow the phase, so the
+        bands are relative to the phase's current slice of the bar.
         """
         assert self._start_percent is not None  # call init() first!
         assert self._stop_percent is not None  # call init() first!
@@ -213,3 +216,32 @@ class ProgressReporter:
         self.update_progress = update
         self.fetch_progress = fetch
         self.upgrade_progress = upgrade
+
+    def set_step_range(
+        self, start: float, stop: float, installs: bool
+    ) -> None:
+        """Allocate a progress range to one release-upgrade step."""
+        active = (
+            (self.fetch_progress, self.upgrade_progress)
+            if installs
+            else (self.update_progress,)
+        )
+        total = sum(phase.weight for phase in active)
+        at = start
+        for phase in active:
+            # With all active weights zero, split the slice evenly rather
+            # than collapsing every phase to a zero-width range.
+            share = phase.weight / total if total else 1 / len(active)
+            span = (stop - start) * share
+            phase.init(at, at + span, self.callback, self.stdout, self.stderr)
+            at += span
+        # Reset inactive phases to start so they don't emit stale progress.
+        for phase in (
+            self.update_progress,
+            self.fetch_progress,
+            self.upgrade_progress,
+        ):
+            if phase not in active:
+                phase.init(
+                    start, start, self.callback, self.stdout, self.stderr
+                )

--- a/vmupdate/agent/source/common/progress_reporter.py
+++ b/vmupdate/agent/source/common/progress_reporter.py
@@ -22,7 +22,7 @@
 import io
 import os
 import sys
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 from logging import Logger
 
 
@@ -84,6 +84,88 @@ class Progress:
         return f"{size:.2f} {units[-1]}"
 
 
+class ReleaseUpgradeTail:
+    """Progress shaping for post-transaction scriptlets during release upgrades.
+
+    Rescales package progress to 0..CAP, then asymptotically advances
+    from CAP to TAIL_STOP as post-transaction scriptlets execute.
+    TAIL_STOP < 100 because qubes.PostInstall still runs afterwards.
+
+    Mixin for Progress subclasses. Inert until open_tail() is called.
+    """
+
+    # Overall percent the package callbacks are rescaled to end at.
+    CAP = 90.0
+    # Overall percent the tail asymptotically approaches.
+    TAIL_STOP = 99.5
+    # Scriptlet count at which the tail band is halfway across.
+    ASYMPTOTE_HALFWAY = 25
+
+    if TYPE_CHECKING:
+        # Supplied by the Progress this mixin is combined with, declared
+        # here only for the type checker.
+        _start_percent: Optional[float]
+        _stop_percent: Optional[float]
+        log: Logger
+
+        def notify_callback(self, percent: float) -> None: ...
+
+    def __init__(self) -> None:
+        self._tail_open = False
+        self._tail_seen = 0
+        self._tail_clamp_logged = False
+
+    def open_tail(self) -> None:
+        """
+        Arm tail shaping for the transaction about to run.
+        """
+        self._tail_open = True
+        self._tail_seen = 0
+
+    def close_tail(self) -> None:
+        """
+        Disarm tail shaping.
+        """
+        self._tail_open = False
+
+    def _scaled_percent(self, local_percent: float) -> float:
+        """Rescale local phase percentage so package progress caps at CAP."""
+        if not self._tail_open:
+            return local_percent
+        cap_local = self._local_for_overall(self.CAP)
+        clamped = min(max(cap_local, 0.0), 100.0)
+        if clamped != cap_local and not self._tail_clamp_logged:
+            self._tail_clamp_logged = True
+            self.log.debug(
+                "tail CAP maps outside the phase slice (%.2f), clamping",
+                cap_local,
+            )
+        return min(local_percent, 100.0) * clamped / 100
+
+    def _local_for_overall(self, overall: float) -> float:
+        """
+        Convert an overall-bar percent into this phase's local percent.
+        """
+        assert self._start_percent is not None  # call init() first!
+        assert self._stop_percent is not None  # call init() first!
+        span = self._stop_percent - self._start_percent
+        if span <= 0:
+            return 100.0
+        return (overall - self._start_percent) / span * 100
+
+    def note_tail_scriptlet(self) -> None:
+        """
+        Advance the bar for one post-transaction scriptlet.
+        """
+        if not self._tail_open:
+            return
+        self._tail_seen += 1
+        overall = self.CAP + (self.TAIL_STOP - self.CAP) * self._tail_seen / (
+            self._tail_seen + self.ASYMPTOTE_HALFWAY
+        )
+        self.notify_callback(min(self._local_for_overall(overall), 100.0))
+
+
 class ProgressReporter:
     """
     Simple rough progress reporter.
@@ -112,9 +194,7 @@ class ProgressReporter:
             emit = callback
 
         def callback_with_memory(percent: float) -> None:
-            # Remember the highest value reported so far, so callers can
-            # tell whether the stream already reached 100 and skip a
-            # duplicate final milestone (PackageManager._finish_progress).
+            # Track highest reported progress to prevent duplicate milestones.
             self.last_percent = max(self.last_percent, percent)
             emit(percent)
 

--- a/vmupdate/agent/source/common/progress_reporter.py
+++ b/vmupdate/agent/source/common/progress_reporter.py
@@ -217,9 +217,7 @@ class ProgressReporter:
         self.fetch_progress = fetch
         self.upgrade_progress = upgrade
 
-    def set_step_range(
-        self, start: float, stop: float, installs: bool
-    ) -> None:
+    def set_step_range(self, start: float, stop: float, installs: bool) -> None:
         """Allocate a progress range to one release-upgrade step."""
         active = (
             (self.fetch_progress, self.upgrade_progress)

--- a/vmupdate/agent/source/dnf/dnf5_api.py
+++ b/vmupdate/agent/source/dnf/dnf5_api.py
@@ -159,6 +159,70 @@ class DNF5(DNFCLI):
             result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=str(exc))
         return result
 
+    def _distro_sync(self, target: str) -> ProcessResult:
+        """
+        Run the release bump through the libdnf5 API, so fetch and
+        transaction progress reach dom0's progress bar as percentages
+        instead of the CLI's bare 0/100 milestones.
+
+        A fresh `libdnf5.base.Base` is built here: `self.base` from
+        `__init__` was already set up against the current releasever.
+        """
+        result = ProcessResult()
+        try:
+            base = libdnf5.base.Base()
+            base.load_config()
+            base.get_config().best = True  # mirror the CLI --best flag
+            # set before setup() so the target release is not overridden
+            # by auto-detection from the running (old) release
+            base.get_vars().set("releasever", target)
+            base.setup()
+
+            repo_sack = base.get_repo_sack()
+            repo_sack.create_repos_from_system_configuration()
+            base.set_download_callbacks(
+                libdnf5.repo.DownloadCallbacksUniquePtr(
+                    self.progress.fetch_progress
+                )
+            )
+            repo_sack.load_repos()
+
+            goal = Goal(base)
+            goal.set_allow_erasing(True)  # mirror --allowerasing
+            goal.add_rpm_distro_sync()
+            transaction = goal.resolve()
+            # fill empty `Command line` column in dnf history
+            transaction.set_description("qubes-vm-update")
+
+            if transaction.get_transaction_packages_count() == 0:
+                self.log.info("Distro-sync found nothing to do.")
+                return result
+
+            transaction.download()
+            if not transaction.check_gpg_signatures():
+                problems = transaction.get_gpg_signature_problems()
+                raise TransactionError(
+                    f"GPG signatures check failed: {problems}"
+                )
+
+            self.log.debug("Committing distro-sync to %s...", target)
+            transaction.set_callbacks(
+                libdnf5.rpm.TransactionCallbacksUniquePtr(
+                    self.progress.upgrade_progress
+                )
+            )
+            tnx_result = transaction.run()
+            if tnx_result != transaction.TransactionRunResult_SUCCESS:
+                raise TransactionError(
+                    transaction.transaction_result_to_string(tnx_result)
+                )
+        except Exception as exc:
+            self.log.error(
+                "An error occurred during release upgrade: %s", str(exc)
+            )
+            result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=str(exc))
+        return result
+
 
 class FetchProgress(DownloadCallbacks, Progress):
     def __init__(self, weight: int, log):

--- a/vmupdate/agent/source/dnf/dnf5_api.py
+++ b/vmupdate/agent/source/dnf/dnf5_api.py
@@ -226,6 +226,11 @@ class DNF5(DNFCLI):
                 message = "Failed to resolve the distro-sync transaction."
                 if details:
                     message += f"\n{details}"
+                print(
+                    "Failed to resolve package dependencies; "
+                    "see the log for details.",
+                    flush=True,
+                )
                 raise TransactionError(message)
 
             if transaction.get_transaction_packages_count() == 0:

--- a/vmupdate/agent/source/dnf/dnf5_api.py
+++ b/vmupdate/agent/source/dnf/dnf5_api.py
@@ -21,8 +21,9 @@
 # USA.
 
 import subprocess
+import time
 from logging import Logger, Handler
-from typing import Any
+from typing import Any, Optional
 
 import libdnf5
 from libdnf5.repo import DownloadCallbacks
@@ -164,6 +165,114 @@ class DNF5(DNFCLI):
             result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=str(exc))
         return result
 
+    def _distro_sync(self, target: str) -> ProcessResult:
+        """Run distro-sync with libdnf5 and report API progress.
+
+        Use a fresh base for the target releasever.
+        """
+        print(
+            "Preparing distribution upgrade; dependency calculation may "
+            "take some time...",
+            flush=True,
+        )
+        result = ProcessResult()
+        try:
+            base = libdnf5.base.Base()
+            base.load_config()
+            base.get_config().best = True  # mirror the CLI --best flag
+            # Set releasever before setup to prevent old-release detection.
+            base.get_vars().set("releasever", target)
+            base.setup()
+
+            repo_sack = base.get_repo_sack()
+            repo_sack.create_repos_from_system_configuration()
+            base.set_download_callbacks(
+                libdnf5.repo.DownloadCallbacksUniquePtr(
+                    self.progress.fetch_progress
+                )
+            )
+            load_started = time.monotonic()
+            repo_sack.load_repos()
+            self.log.debug(
+                "dnf5 repo load for release %s took %.3fs",
+                target,
+                time.monotonic() - load_started,
+            )
+
+            goal = Goal(base)
+            goal.set_allow_erasing(True)  # mirror --allowerasing
+            goal.add_rpm_distro_sync()
+            print("Calculating package changes...", flush=True)
+            resolve_started = time.monotonic()
+            transaction = goal.resolve()
+            self.log.debug(
+                "dnf5 dependency resolution for release %s took %.3fs",
+                target,
+                time.monotonic() - resolve_started,
+            )
+            # fill empty `Command line` column in dnf history
+            transaction.set_description("qubes-vm-update")
+
+            if transaction.get_transaction_packages_count() == 0:
+                self.log.info("Distro-sync found nothing to do.")
+                return result
+
+            # Size the download before it starts; see expect_bytes().
+            self.progress.fetch_progress.expect_bytes(
+                planned_download_bytes(transaction, self.log)
+            )
+            download_started = time.monotonic()
+            transaction.download()
+            self.log.debug(
+                "dnf5 package download for release %s took %.3fs",
+                target,
+                time.monotonic() - download_started,
+            )
+            if not transaction.check_gpg_signatures():
+                problems = transaction.get_gpg_signature_problems()
+                raise TransactionError(
+                    f"GPG signatures check failed: {problems}"
+                )
+
+            self.log.debug("Committing distro-sync to %s...", target)
+            transaction.set_callbacks(
+                libdnf5.rpm.TransactionCallbacksUniquePtr(
+                    self.progress.upgrade_progress
+                )
+            )
+            transaction_started = time.monotonic()
+            tnx_result = transaction.run()
+            self.log.debug(
+                "dnf5 transaction for release %s took %.3fs",
+                target,
+                time.monotonic() - transaction_started,
+            )
+            if tnx_result != transaction.TransactionRunResult_SUCCESS:
+                raise TransactionError(
+                    transaction.transaction_result_to_string(tnx_result)
+                )
+        except Exception as exc:
+            self.log.error(
+                "An error occurred during release upgrade: %s", str(exc)
+            )
+            result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=str(exc))
+        return result
+
+
+def planned_download_bytes(transaction, log: Logger) -> float:
+    """Return package bytes to download, or 0 when unavailable."""
+    try:
+        is_inbound = libdnf5.base.transaction.transaction_item_action_is_inbound
+        total = 0.0
+        for item in transaction.get_transaction_packages():
+            # Exclude erased and replaced entries from the download total.
+            if is_inbound(item.get_action()):
+                total += item.get_package().get_download_size()
+        return total
+    except Exception:  # pylint: disable=broad-except
+        log.debug("cannot size the download up front", exc_info=True)
+        return 0.0
+
 
 class FetchProgress(DownloadCallbacks, Progress):
     def __init__(self, weight: int, log: Logger) -> None:
@@ -171,10 +280,24 @@ class FetchProgress(DownloadCallbacks, Progress):
         Progress.__init__(self, weight, log)
         self.bytes_to_fetch = 0.0
         self.bytes_fetched = 0.0
+        self.expected_bytes = 0.0
         self.package_bytes: dict[int, float] = {}
         self.package_names: dict[int, str] = {}
         self.count = 0
         self.fetching_notified = False
+
+    def expect_bytes(self, total: float) -> None:
+        """Reset download counters and set the expected package download size."""
+        self.bytes_fetched = 0.0
+        self.bytes_to_fetch = 0.0
+        self.fetching_notified = False
+        if total > 0:
+            self.expected_bytes = float(total)
+
+    @property
+    def download_total(self) -> float:
+        """Return the expected or accumulated download total, whichever is larger."""
+        return max(self.bytes_to_fetch, self.expected_bytes)
 
     def add_new_download(
         self, _user_data: Any, description: str, total_to_download: float
@@ -188,7 +311,10 @@ class FetchProgress(DownloadCallbacks, Progress):
         :return: Associated user data for new download.
         """
         self.count += 1
-        self.bytes_to_fetch += total_to_download
+        # libdnf5 reports unknown sizes as -1; don't let those poison the
+        # total (e.g. "Fetching 4 packages [-4.00 B]").
+        if total_to_download > 0:
+            self.bytes_to_fetch += total_to_download
         self.package_bytes[self.count] = 0
         self.package_names[self.count] = description
         # downloading is not started yet
@@ -208,21 +334,27 @@ class FetchProgress(DownloadCallbacks, Progress):
         if not self.fetching_notified:
             print(
                 f"Fetching {self.count} packages "
-                f"[{self._format_bytes(self.bytes_to_fetch)}]",
+                f"[{self._format_bytes(self.download_total)}]",
                 flush=True,
             )
             self.fetching_notified = True
         self.bytes_fetched += downloaded - self.package_bytes[user_cb_data]
         if downloaded > self.package_bytes[user_cb_data]:
             if self.package_bytes[user_cb_data] == 0:
+                size = (
+                    self._format_bytes(total_to_download)
+                    if total_to_download > 0
+                    else "unknown size"
+                )
                 print(
-                    f"Fetching {self.package_names[user_cb_data]} "
-                    f"[{self._format_bytes(total_to_download)}]",
+                    f"Fetching {self.package_names[user_cb_data]} [{size}]",
                     flush=True,
                 )
             self.package_bytes[user_cb_data] = downloaded
-            percent = self.bytes_fetched / self.bytes_to_fetch * 100
-            self.notify_callback(percent)
+            # Do not divide by an unknown-size total.
+            total = self.download_total
+            if total > 0:
+                self.notify_callback(min(self.bytes_fetched / total * 100, 100))
         # Should return 0 on success,
         # in case anything in dnf5 changed we return their default value
         return DownloadCallbacks.progress(
@@ -245,7 +377,7 @@ class FetchProgress(DownloadCallbacks, Progress):
         return DownloadCallbacks.end(self, user_cb_data, status, msg)
 
     def mirror_failure(
-        self, user_cb_data: int, msg: str, url: str, metadata: str
+        self, user_cb_data: int, msg: str, url: str, metadata: Optional[str]
     ) -> int:
         """
         Mirror failure callback.
@@ -257,8 +389,10 @@ class FetchProgress(DownloadCallbacks, Progress):
         """
         if isinstance(msg, bytes):
             msg = msg.decode("ascii", errors="ignore")
+        # libdnf5 passes no metadata type for plain package downloads
+        # (avoid "Fetching None failure (...)").
         print(
-            f"Fetching {metadata} failure "
+            f"Fetching {metadata or 'package'} failure "
             f"({self.package_names[user_cb_data]}) {msg}",
             flush=True,
             file=self._stdout,

--- a/vmupdate/agent/source/dnf/dnf5_api.py
+++ b/vmupdate/agent/source/dnf/dnf5_api.py
@@ -217,6 +217,17 @@ class DNF5(DNFCLI):
             # fill empty `Command line` column in dnf history
             transaction.set_description("qubes-vm-update")
 
+            if (
+                transaction.get_problems()
+                != libdnf5.base.GoalProblem_NO_PROBLEM
+            ):
+                logs = transaction.get_resolve_logs_as_strings()
+                details = "\n".join(logs)
+                message = "Failed to resolve the distro-sync transaction."
+                if details:
+                    message += f"\n{details}"
+                raise TransactionError(message)
+
             if transaction.get_transaction_packages_count() == 0:
                 self.log.info("Distro-sync found nothing to do.")
                 return result

--- a/vmupdate/agent/source/dnf/dnf5_api.py
+++ b/vmupdate/agent/source/dnf/dnf5_api.py
@@ -32,7 +32,11 @@ from libdnf5.base import Goal
 
 from source.common.process_result import ProcessResult
 from source.common.exit_codes import EXIT
-from source.common.progress_reporter import ProgressReporter, Progress
+from source.common.progress_reporter import (
+    ProgressReporter,
+    Progress,
+    ReleaseUpgradeTail,
+)
 from source.common.package_manager import AgentType
 
 from .dnf_cli import DNFCLI
@@ -240,8 +244,14 @@ class DNF5(DNFCLI):
                     self.progress.upgrade_progress
                 )
             )
+            # The post-transaction scriptlets run for minutes after the
+            # last package installs. See ReleaseUpgradeTail.
+            self.progress.upgrade_progress.open_tail()
             transaction_started = time.monotonic()
-            tnx_result = transaction.run()
+            try:
+                tnx_result = transaction.run()
+            finally:
+                self.progress.upgrade_progress.close_tail()
             self.log.debug(
                 "dnf5 transaction for release %s took %.3fs",
                 target,
@@ -257,6 +267,16 @@ class DNF5(DNFCLI):
             )
             result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=str(exc))
         return result
+
+
+def tail_marker_types() -> frozenset[int]:
+    """Return libdnf5 ScriptType values marking the start of post-transaction scriptlets."""
+    names = ("ScriptType_POST_TRANSACTION", "ScriptType_POSTUN_TRANSACTION")
+    values = (getattr(TransactionCallbacks, name, None) for name in names)
+    return frozenset(int(v) for v in values if isinstance(v, int))
+
+
+TAIL_MARKER_TYPES = tail_marker_types()
 
 
 def planned_download_bytes(transaction, log: Logger) -> float:
@@ -402,13 +422,16 @@ class FetchProgress(DownloadCallbacks, Progress):
         )
 
 
-class UpgradeProgress(TransactionCallbacks, Progress):
+class UpgradeProgress(TransactionCallbacks, ReleaseUpgradeTail, Progress):
     def __init__(self, weight: int, log: Logger) -> None:
         TransactionCallbacks.__init__(self)
         Progress.__init__(self, weight, log)
+        # Armed by _distro_sync() only, so ordinary runs are unaffected.
+        ReleaseUpgradeTail.__init__(self)
         self.pgks: int | None = None
         self.pgks_done: int | None = None
         self.processed_packages: set[str] = set()
+        self.tail_reached = False
 
     def install_progress(
         self, item: libdnf5.base.TransactionPackage, amount: int, total: int
@@ -429,7 +452,7 @@ class UpgradeProgress(TransactionCallbacks, Progress):
         assert isinstance(self.pgks_done, int)
         assert isinstance(self.pgks, int)
         percent = (self.pgks_done + pkg_progress) / self.pgks * 100
-        self.notify_callback(percent)
+        self.notify_callback(self._scaled_percent(percent))
 
     def transaction_start(self, total: int) -> None:
         r"""
@@ -439,6 +462,7 @@ class UpgradeProgress(TransactionCallbacks, Progress):
         """
         self.pgks_done = 0
         self.pgks = total
+        self.tail_reached = False
 
     def uninstall_progress(
         self, item: libdnf5.base.TransactionPackage, amount: int, total: int
@@ -458,7 +482,7 @@ class UpgradeProgress(TransactionCallbacks, Progress):
         assert isinstance(self.pgks_done, int)
         assert isinstance(self.pgks, int)
         percent = (self.pgks_done + pkg_progress) / self.pgks * 100
-        self.notify_callback(percent)
+        self.notify_callback(self._scaled_percent(percent))
 
     # pylint: disable=unused-argument
     def elem_progress(
@@ -475,7 +499,7 @@ class UpgradeProgress(TransactionCallbacks, Progress):
         """
         self.pgks_done = amount
         percent = amount / total * 100
-        self.notify_callback(percent)
+        self.notify_callback(self._scaled_percent(percent))
 
     # pylint: disable=unused-argument,redefined-builtin
     def script_start(
@@ -501,3 +525,9 @@ class UpgradeProgress(TransactionCallbacks, Progress):
             f":{nevra.get_version()}-{nevra.get_release()}.{nevra.get_arch()}",
             flush=True,
         )
+        # The ~1500 scriptlets before the tail are interleaved with the
+        # package loop, which reports its own progress.
+        if type in TAIL_MARKER_TYPES:
+            self.tail_reached = True
+        if self.tail_reached:
+            self.note_tail_scriptlet()

--- a/vmupdate/agent/source/dnf/dnf_api.py
+++ b/vmupdate/agent/source/dnf/dnf_api.py
@@ -160,6 +160,52 @@ class DNF(DNFCLI):
 
         return result
 
+    def _distro_sync(self, target: str) -> ProcessResult:
+        """
+        Run the release bump through the dnf API, so fetch and
+        transaction progress reach dom0's progress bar as percentages
+        instead of the CLI's bare 0/100 milestones.
+
+        A fresh `dnf.Base` is built here: `self.base` from `__init__`
+        already resolved its substitutions and repos against the
+        current releasever.
+        """
+        result = ProcessResult()
+        try:
+            conf = dnf.conf.Conf()
+            conf.read()
+            # mirror the CLI flags: --best (--allowerasing is set on
+            # resolve below)
+            conf.best = True
+            conf.substitutions["releasever"] = target
+            base = dnf.Base(conf)
+            try:
+                base.read_all_repos()
+                base.fill_sack()
+                base.distro_sync()
+                # fill empty `Command line` column in dnf history
+                base.cmds = ["qubes-vm-update"]
+                base.resolve(allow_erasing=True)
+                trans = base.transaction
+                if not trans:
+                    self.log.info("Distro-sync found nothing to do.")
+                    return result
+                base.download_packages(
+                    trans.install_set, progress=self.progress.fetch_progress
+                )
+                result += sign_check(base, trans.install_set, self.log)
+                if result.code == EXIT.OK:
+                    self.log.debug("Committing distro-sync to %s...", target)
+                    base.do_transaction(self.progress.upgrade_progress)
+            finally:
+                base.close()
+        except Exception as exc:
+            self.log.error(
+                "An error occurred during release upgrade: %s", str(exc)
+            )
+            result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=str(exc))
+        return result
+
 
 def sign_check(base, packages, log) -> ProcessResult:
     """

--- a/vmupdate/agent/source/dnf/dnf_api.py
+++ b/vmupdate/agent/source/dnf/dnf_api.py
@@ -20,6 +20,7 @@
 # USA.
 
 import os
+import time
 import subprocess
 from logging import Handler, Logger
 from typing import Iterable
@@ -164,6 +165,74 @@ class DNF(DNFCLI):
         finally:
             self.base.close()
 
+        return result
+
+    def _distro_sync(self, target: str) -> ProcessResult:
+        """Run release upgrade via DNF API with callback progress reporting."""
+        print(
+            "Preparing distribution upgrade; dependency calculation may "
+            "take some time...",
+            flush=True,
+        )
+        result = ProcessResult()
+        try:
+            conf = dnf.conf.Conf()
+            conf.read()
+            # mirror the CLI flags: --best (--allowerasing is set on
+            # resolve below)
+            conf.best = True
+            conf.substitutions["releasever"] = target
+            base = dnf.Base(conf)
+            try:
+                base.read_all_repos()
+                fill_sack_started = time.monotonic()
+                base.fill_sack()
+                self.log.debug(
+                    "dnf fill_sack for release %s took %.3fs",
+                    target,
+                    time.monotonic() - fill_sack_started,
+                )
+                base.distro_sync()
+                # fill empty `Command line` column in dnf history
+                base.cmds = ["qubes-vm-update"]
+                print("Calculating package changes...", flush=True)
+                resolve_started = time.monotonic()
+                base.resolve(allow_erasing=True)
+                self.log.debug(
+                    "dnf dependency resolution for release %s took %.3fs",
+                    target,
+                    time.monotonic() - resolve_started,
+                )
+                trans = base.transaction
+                if not trans:
+                    self.log.info("Distro-sync found nothing to do.")
+                    return result
+                download_started = time.monotonic()
+                base.download_packages(
+                    trans.install_set, progress=self.progress.fetch_progress
+                )
+                self.log.debug(
+                    "dnf package download for release %s took %.3fs",
+                    target,
+                    time.monotonic() - download_started,
+                )
+                result += sign_check(base, trans.install_set, self.log)
+                if result.code == EXIT.OK:
+                    self.log.debug("Committing distro-sync to %s...", target)
+                    transaction_started = time.monotonic()
+                    base.do_transaction(self.progress.upgrade_progress)
+                    self.log.debug(
+                        "dnf transaction for release %s took %.3fs",
+                        target,
+                        time.monotonic() - transaction_started,
+                    )
+            finally:
+                base.close()
+        except Exception as exc:
+            self.log.error(
+                "An error occurred during release upgrade: %s", str(exc)
+            )
+            result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=str(exc))
         return result
 
 

--- a/vmupdate/agent/source/dnf/dnf_api.py
+++ b/vmupdate/agent/source/dnf/dnf_api.py
@@ -34,7 +34,11 @@ import dnf.transaction
 
 from source.common.process_result import ProcessResult
 from source.common.exit_codes import EXIT
-from source.common.progress_reporter import ProgressReporter, Progress
+from source.common.progress_reporter import (
+    ProgressReporter,
+    Progress,
+    ReleaseUpgradeTail,
+)
 from source.common.package_manager import AgentType
 
 from .dnf_cli import DNFCLI
@@ -219,8 +223,13 @@ class DNF(DNFCLI):
                 result += sign_check(base, trans.install_set, self.log)
                 if result.code == EXIT.OK:
                     self.log.debug("Committing distro-sync to %s...", target)
+                    # Enable tail progress shaping for post-transaction scriptlets.
+                    self.progress.upgrade_progress.open_tail()
                     transaction_started = time.monotonic()
-                    base.do_transaction(self.progress.upgrade_progress)
+                    try:
+                        base.do_transaction(self.progress.upgrade_progress)
+                    finally:
+                        self.progress.upgrade_progress.close_tail()
                     self.log.debug(
                         "dnf transaction for release %s took %.3fs",
                         target,
@@ -329,10 +338,12 @@ class FetchProgress(DownloadProgress, Progress):
         self.notify_callback(0)
 
 
-class UpgradeProgress(TransactionDisplay, Progress):
+class UpgradeProgress(TransactionDisplay, ReleaseUpgradeTail, Progress):
     def __init__(self, weight: int, log: Logger) -> None:
         TransactionDisplay.__init__(self)
         Progress.__init__(self, weight, log)
+        # Armed by _distro_sync() only, so ordinary runs are unaffected.
+        ReleaseUpgradeTail.__init__(self)
 
     def progress(
         self,
@@ -354,12 +365,14 @@ class UpgradeProgress(TransactionDisplay, Progress):
         :param ts_total: total number of actions in the whole transaction
         """
         self.log.info(_package)
-        fetch = 6
-        install = 7
-        if action not in (fetch, install):
+        # libdnf TransactionItemAction values: 6 is UPGRADE, 7 is
+        # UPGRADED (the cleanup element of an upgraded package).
+        upgrade = 6
+        upgraded_cleanup = 7
+        if action not in (upgrade, upgraded_cleanup):
             return
         percent = (ti_done / ti_total + ts_done - 1) / ts_total * 100
-        self.notify_callback(percent)
+        self.notify_callback(self._scaled_percent(percent))
 
     def scriptout(self, msgs: bytes | str) -> None:
         """

--- a/vmupdate/agent/source/dnf/dnf_cli.py
+++ b/vmupdate/agent/source/dnf/dnf_cli.py
@@ -150,6 +150,8 @@ class DNFCLI(PackageManager):
         We point dnf/yum at the target ``--releasever`` and let
         `distro-sync` converge the whole package set onto that release; a
         plain `upgrade` would leave a mix of old and new release packages.
+        The bump itself runs through `_distro_sync`, which the API
+        subclasses override with callback-driven progress reporting.
         """
         target = str(target_version).strip()
 
@@ -168,7 +170,26 @@ class DNFCLI(PackageManager):
             result.code = EXIT.ERR_VM_UPDATE
             return result
 
-        upgrade = self.run_cmd(
+        upgrade = self._distro_sync(target)
+        if upgrade.code:
+            upgrade.code = EXIT.ERR_VM_UPDATE
+            result += upgrade
+            return result
+
+        result += upgrade
+        self._report_progress(100.0)
+        return result
+
+    def _distro_sync(self, target: str) -> ProcessResult:
+        """
+        Run the release bump with the dnf command line.
+
+        A whole-release CLI distro-sync has no usable fine-grained
+        progress, so the streamed package output is what gives the user
+        liveliness. The API subclasses (DNF, DNF5) override this with
+        callback-driven progress reporting.
+        """
+        return self.run_cmd(
             [
                 self.package_manager,
                 f"--releasever={target}",
@@ -178,14 +199,6 @@ class DNFCLI(PackageManager):
                 "--assumeyes",
             ]
         )
-        if upgrade.code:
-            upgrade.code = EXIT.ERR_VM_UPDATE
-            result += upgrade
-            return result
-
-        result += upgrade
-        self._report_progress(100.0)
-        return result
 
     def clean(self) -> int:
         """

--- a/vmupdate/agent/source/dnf/dnf_cli.py
+++ b/vmupdate/agent/source/dnf/dnf_cli.py
@@ -19,7 +19,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
 # USA.
 
-import sys
 import shutil
 from typing import List
 
@@ -148,35 +147,20 @@ class DNFCLI(PackageManager):
         """
         Move the qube to a new Fedora/RHEL release with `distro-sync`.
 
-        Crossing a release boundary is not the same as a normal update:
-        we point dnf/yum at the *target* `--releasever` and let
-        `distro-sync` converge the whole package set onto that release
-        (installing, upgrading, and erasing as needed). A plain `upgrade`
-        would leave the system on a mix of old and new release packages.
-
-        dom0 derives `target_version` from `os-*` qvm-features that this
-        agent wrote on an earlier boot, and those can drift, so we re-read
-        the distribution from inside the qube and refuse on any mismatch
-        before doing anything irreversible.
-
-        Progress is reported as bare floats on stderr (one per line),
-        which dom0's QubeConnection parses to drive the progress bar.
-        0 at the start and 100 once distro-sync succeeds. A whole-release
-        distro-sync has no usable fine-grained progress, so the streamed
-        package output is what gives the user liveliness.
+        We point dnf/yum at the target ``--releasever`` and let
+        `distro-sync` converge the whole package set onto that release; a
+        plain `upgrade` would leave a mix of old and new release packages.
         """
         target = str(target_version).strip()
 
-        # Re-verify from in-qube data before we touch anything.
-        guard = self._verify_release_upgrade(target)
+        guard = self._verify_release_upgrade(target, get_os_data(self.log))
         if guard.code:
             return guard
 
         self._report_progress(0.0)
 
-        # Wipe metadata and packages cached for the *old* release; otherwise
+        # wipe metadata and packages cached for the old release; otherwise
         # dnf may resolve the transaction against the previous releasever
-        # and land on an inconsistent set.
         result = self.run_cmd(
             [self.package_manager, "clean", "all"], realtime=False
         )
@@ -184,7 +168,6 @@ class DNFCLI(PackageManager):
             result.code = EXIT.ERR_VM_UPDATE
             return result
 
-        # The actual release bump.
         upgrade = self.run_cmd(
             [
                 self.package_manager,
@@ -203,52 +186,6 @@ class DNFCLI(PackageManager):
         result += upgrade
         self._report_progress(100.0)
         return result
-
-    def _verify_release_upgrade(self, target: str) -> ProcessResult:
-        """
-        Confirm, from inside the qube, that a release upgrade to `target`
-        is sane. Returns an errored ProcessResult to abort, or an empty
-        (code 0) result to proceed.
-
-        Enforces a single-step jump: the target must be a plain release
-        number and exactly one greater than the current in-qube major release.
-        This mirrors dom0's `compute_target_version`, ruling out downgrades,
-        no-ops, and multi-step jumps.
-        """
-        if not target.isdigit():
-            return self._refuse(f"invalid target release {target!r}.")
-
-        os_data = get_os_data(self.log)
-        current_major = os_data.get("release", "").split(".")[0]
-        if not current_major.isdigit():
-            return self._refuse(
-                f"cannot read a numeric in-qube release from "
-                f"{os_data.get('release')!r}."
-            )
-        if int(target) != int(current_major) + 1:
-            return self._refuse(
-                f"in-qube release {os_data.get('release')!r} can only move "
-                f"to {int(current_major) + 1} (single step), not {target!r}."
-            )
-
-        return ProcessResult()
-
-    def _refuse(self, reason: str) -> ProcessResult:
-        """Log and build the standard "refusing version upgrade" error."""
-        msg = f"Refusing version upgrade: {reason}"
-        self.log.error(msg)
-        return ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=msg)
-
-    @staticmethod
-    def _report_progress(percent: float) -> None:
-        """
-        Emit a progress milestone for dom0's progress bar.
-
-        The agent-to-dom0 progress protocol writes a bare float value
-        (one per line) to stderr; dom0's QubeConnection reads these
-        to drive the progress bar.  100.0 signals completion.
-        """
-        print(f"{percent:.2f}", flush=True, file=sys.stderr)
 
     def clean(self) -> int:
         """

--- a/vmupdate/agent/source/dnf/dnf_cli.py
+++ b/vmupdate/agent/source/dnf/dnf_cli.py
@@ -19,9 +19,11 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
 # USA.
 
+import sys
 import shutil
 from typing import List
 
+from source.utils import get_os_data
 from source.common.package_manager import PackageManager, AgentType
 from source.common.process_result import ProcessResult
 from source.common.exit_codes import EXIT
@@ -141,6 +143,112 @@ class DNFCLI(PackageManager):
                 # yum
                 result.append("update")
         return result
+
+    def _release_upgrade(self, target_version: str) -> ProcessResult:
+        """
+        Move the qube to a new Fedora/RHEL release with `distro-sync`.
+
+        Crossing a release boundary is not the same as a normal update:
+        we point dnf/yum at the *target* `--releasever` and let
+        `distro-sync` converge the whole package set onto that release
+        (installing, upgrading, and erasing as needed). A plain `upgrade`
+        would leave the system on a mix of old and new release packages.
+
+        dom0 derives `target_version` from `os-*` qvm-features that this
+        agent wrote on an earlier boot, and those can drift, so we re-read
+        the distribution from inside the qube and refuse on any mismatch
+        before doing anything irreversible.
+
+        Progress is reported as bare floats on stderr (one per line),
+        which dom0's QubeConnection parses to drive the progress bar.
+        0 at the start and 100 once distro-sync succeeds. A whole-release
+        distro-sync has no usable fine-grained progress, so the streamed
+        package output is what gives the user liveliness.
+        """
+        target = str(target_version).strip()
+
+        # Re-verify from in-qube data before we touch anything.
+        guard = self._verify_release_upgrade(target)
+        if guard.code:
+            return guard
+
+        self._report_progress(0.0)
+
+        # Wipe metadata and packages cached for the *old* release; otherwise
+        # dnf may resolve the transaction against the previous releasever
+        # and land on an inconsistent set.
+        result = self.run_cmd(
+            [self.package_manager, "clean", "all"], realtime=False
+        )
+        if result.code:
+            result.code = EXIT.ERR_VM_UPDATE
+            return result
+
+        # The actual release bump.
+        upgrade = self.run_cmd(
+            [
+                self.package_manager,
+                f"--releasever={target}",
+                "distro-sync",
+                "--best",
+                "--allowerasing",
+                "--assumeyes",
+            ]
+        )
+        if upgrade.code:
+            upgrade.code = EXIT.ERR_VM_UPDATE
+            result += upgrade
+            return result
+
+        result += upgrade
+        self._report_progress(100.0)
+        return result
+
+    def _verify_release_upgrade(self, target: str) -> ProcessResult:
+        """
+        Confirm, from inside the qube, that a release upgrade to `target`
+        is sane. Returns an errored ProcessResult to abort, or an empty
+        (code 0) result to proceed.
+
+        Enforces a single-step jump: the target must be a plain release
+        number and exactly one greater than the current in-qube major release.
+        This mirrors dom0's `compute_target_version`, ruling out downgrades,
+        no-ops, and multi-step jumps.
+        """
+        if not target.isdigit():
+            return self._refuse(f"invalid target release {target!r}.")
+
+        os_data = get_os_data(self.log)
+        current_major = os_data.get("release", "").split(".")[0]
+        if not current_major.isdigit():
+            return self._refuse(
+                f"cannot read a numeric in-qube release from "
+                f"{os_data.get('release')!r}."
+            )
+        if int(target) != int(current_major) + 1:
+            return self._refuse(
+                f"in-qube release {os_data.get('release')!r} can only move "
+                f"to {int(current_major) + 1} (single step), not {target!r}."
+            )
+
+        return ProcessResult()
+
+    def _refuse(self, reason: str) -> ProcessResult:
+        """Log and build the standard "refusing version upgrade" error."""
+        msg = f"Refusing version upgrade: {reason}"
+        self.log.error(msg)
+        return ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=msg)
+
+    @staticmethod
+    def _report_progress(percent: float) -> None:
+        """
+        Emit a progress milestone for dom0's progress bar.
+
+        The agent-to-dom0 progress protocol writes a bare float value
+        (one per line) to stderr; dom0's QubeConnection reads these
+        to drive the progress bar.  100.0 signals completion.
+        """
+        print(f"{percent:.2f}", flush=True, file=sys.stderr)
 
     def clean(self) -> int:
         """

--- a/vmupdate/agent/source/dnf/dnf_cli.py
+++ b/vmupdate/agent/source/dnf/dnf_cli.py
@@ -28,7 +28,11 @@ import string
 import subprocess
 
 from source.utils import get_os_data
-from source.common.package_manager import PackageManager, AgentType
+from source.common.package_manager import (
+    PackageManager,
+    AgentType,
+    RELEASE_UPGRADE_ALMOST_DONE,
+)
 from source.common.process_result import ProcessResult
 from source.common.exit_codes import EXIT
 
@@ -243,7 +247,8 @@ class DNFCLI(PackageManager):
             result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=msg)
             return result
 
-        self._finish_progress()
+        # version_upgrade() owns the jump to 100, after qubes.PostInstall.
+        self._report_milestone(RELEASE_UPGRADE_ALMOST_DONE)
         return result
 
     def _distro_sync(self, target: str) -> ProcessResult:

--- a/vmupdate/agent/source/dnf/dnf_cli.py
+++ b/vmupdate/agent/source/dnf/dnf_cli.py
@@ -27,6 +27,7 @@ import random
 import string
 import subprocess
 
+from source.utils import get_os_data
 from source.common.package_manager import PackageManager, AgentType
 from source.common.process_result import ProcessResult
 from source.common.exit_codes import EXIT
@@ -190,6 +191,73 @@ class DNFCLI(PackageManager):
                 # yum
                 result.append("update")
         return result
+
+    def _release_upgrade(self, target_version: str) -> ProcessResult:
+        """Move a Fedora/RHEL qube with distro-sync at target releasever."""
+        target = str(target_version).strip()
+
+        # _distro_sync uses dnf-only flags (--best, --allowerasing).
+        if self.package_manager == "yum":
+            return self._refuse("release upgrade requires dnf.")
+
+        try:
+            os_data = get_os_data(self.log)
+        except OSError as exc:
+            return self._refuse(f"cannot read os-release: {exc}")
+
+        guard = self._verify_release_upgrade(target, os_data)
+        if guard.code:
+            return guard
+
+        self._report_progress(0.0)
+
+        # Clear old-release caches before resolving the target transaction.
+        result = self.run_cmd(
+            [self.package_manager, "clean", "all"], realtime=False
+        )
+        if result.code:
+            result.code = EXIT.ERR_VM_UPDATE
+            return result
+
+        result += self._distro_sync(target)
+        if result.code:
+            result.code = EXIT.ERR_VM_UPDATE
+            return result
+
+        # Verify os-release reflects the target release.
+        try:
+            upgraded_os_data = get_os_data(self.log)
+        except OSError as exc:
+            msg = f"failed to verify the upgraded release: {exc}"
+            self.log.error(msg)
+            result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=msg)
+            return result
+
+        upgraded_release = upgraded_os_data.get("release", "").split(".")[0]
+        if upgraded_release != target:
+            msg = (
+                f"release upgrade did not reach {target}; os-release "
+                f"reports {upgraded_os_data.get('release')!r}."
+            )
+            self.log.error(msg)
+            result += ProcessResult(EXIT.ERR_VM_UPDATE, out="", err=msg)
+            return result
+
+        self._finish_progress()
+        return result
+
+    def _distro_sync(self, target: str) -> ProcessResult:
+        """Run distro-sync for the target release via DNF CLI."""
+        return self.run_cmd(
+            [
+                self.package_manager,
+                f"--releasever={target}",
+                "distro-sync",
+                "--best",
+                "--allowerasing",
+                "--assumeyes",
+            ]
+        )
 
     def clean(self) -> int:
         """

--- a/vmupdate/agent/source/dnf/dnf_cli.py
+++ b/vmupdate/agent/source/dnf/dnf_cli.py
@@ -51,7 +51,6 @@ class DNFCLI(PackageManager):
                 break
         else:
             raise RuntimeError("Package manager not found!")
-        self.package_manager: str = pck_mngr
 
     def configure_whonix_maybe(self, conf):
         """

--- a/vmupdate/agent/source/pacman/pacman_cli.py
+++ b/vmupdate/agent/source/pacman/pacman_cli.py
@@ -82,3 +82,13 @@ class PACMANCLI(PackageManager):
         result = self.run_cmd(cmd, realtime=False)
         return_code = EXIT.ERR_VM_CLEANUP if result.code != 0 else 0
         return return_code
+
+    def _release_upgrade(self, target_version: str) -> ProcessResult:
+        """
+        Arch Linux is a rolling release with no discrete versions to move
+        between, so there is nothing for this to do.
+        """
+        raise NotImplementedError(
+            "Distribution version upgrade is not applicable to pacman: "
+            "Arch Linux is a rolling release."
+        )

--- a/vmupdate/agent/source/pacman/pacman_cli.py
+++ b/vmupdate/agent/source/pacman/pacman_cli.py
@@ -85,3 +85,13 @@ class PACMANCLI(PackageManager):
         result = self.run_cmd(cmd, realtime=False)
         return_code = EXIT.ERR_VM_CLEANUP if result.code != 0 else 0
         return return_code
+
+    def _release_upgrade(self, target_version: str) -> ProcessResult:
+        """
+        Arch Linux is a rolling release with no discrete versions to move
+        between, so there is nothing for this to do.
+        """
+        raise NotImplementedError(
+            "Distribution version upgrade is not applicable to pacman: "
+            "Arch Linux is a rolling release."
+        )

--- a/vmupdate/qube_connection.py
+++ b/vmupdate/qube_connection.py
@@ -335,6 +335,12 @@ class QubeConnection:
                     StatusInfo.updating(self.qube, progress)
                 )
             else:
+                # Ignore duplicate 100.0 milestone from agents that emit it twice.
+                try:
+                    if float(line) == 100.0:
+                        continue
+                except ValueError:
+                    pass
                 self.status_notifier.put(
                     FormatedLine(self.qube.name, "err", line)
                 )

--- a/vmupdate/template_upgrade.py
+++ b/vmupdate/template_upgrade.py
@@ -1,0 +1,399 @@
+#!/usr/bin/python3
+"""
+qvm-template-upgrade — perform an N -> N+1 distro version upgrade of a qube
+
+Workflow:
+    1. Validate that --template names an existing TemplateVM or StandaloneVM.
+    2. Read os-distribution / os-version from qvm-features.
+    3. Compute the target version as os-version + 1 (N -> N+1 is the
+       only supported scope; multi-hop is rejected by construction).
+    4. Clone the qube to a new name derived from the target version.
+    5. Run the in-VM version-upgrade agent inside the clone
+        (reuses the vmupdate qrexec transport — currently stubbed).
+    6. On success: update template metadata features on the clone.
+    7. On failure: remove the half-upgraded clone unless
+       --keep-new-on-failure.
+
+The original qube is never touched by this tool. AppVMs based on a source
+template continue to use it until the user manually switches them and
+uninstalls the old template.
+"""
+
+import argparse
+import logging
+import sys
+from datetime import datetime, timezone
+from typing import Optional, Sequence, Tuple
+
+import qubesadmin
+import qubesadmin.app
+import qubesadmin.exc
+import qubesadmin.tools
+import qubesadmin.vm
+
+from vmupdate.agent.source.common.exit_codes import EXIT
+
+LOG_PATH = "/var/log/qubes/qvm-template-upgrade.log"
+LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
+
+SUPPORTED_DISTROS = {"fedora", "debian"}
+SUPPORTED_CLASSES = {"TemplateVM", "StandaloneVM"}
+
+DATE_FMT = "%Y-%m-%d %H:%M:%S"
+
+
+class UpgradeError(Exception):
+    """Failure during the upgrade run itself."""
+
+
+class ValidationError(Exception):
+    """Invalid user input or unsupported source qube."""
+
+
+def compute_target_version(current: str) -> str:
+    """Return current + 1 as the target distro version.
+
+    Non-integer versions are rejected here.
+    """
+    try:
+        current_n = int(current)
+    except ValueError as exc:
+        raise ValidationError(
+            f"Non-numeric distro version {current!r}; multi-component "
+            f"versions (e.g. Debian point releases) are not yet supported "
+            f"by this tool."
+        ) from exc
+    return str(current_n + 1)
+
+
+def derive_clone_name(
+    source_name: str,
+    current_version: str,
+    target_version: str,
+    override: Optional[str],
+) -> str:
+    """Replace the version in the source name with the target version.
+
+    Examples:
+        fedora-41, 41 -> 42  =>  fedora-42
+
+        fedora-41-minimal, 41 -> 42  =>  fedora-42-minimal
+
+        custom, 41 -> 42  =>  custom-42
+    """
+    if override:
+        return override
+    if current_version not in source_name:
+        return f"{source_name}-{target_version}"
+    # Replace only the last occurrence (e.g. fedora-41-extras-41 stays sane).
+    head, _, tail = source_name.rpartition(current_version)
+    return f"{head}{target_version}{tail}"
+
+
+# Argument parsing / logging
+
+
+def get_parser() -> qubesadmin.tools.QubesArgumentParser:
+    parser = qubesadmin.tools.QubesArgumentParser(
+        prog="qvm-template-upgrade",
+        description="Upgrade a TemplateVM or StandaloneVM to the next distro "
+        "version.",
+        # Disable --version: this tool has no standalone version, and the
+        # default path reads qubesadmin's package metadata, which is absent
+        # when qubesadmin is only on PYTHONPATH (e.g. in tests/CI).
+        version="",
+    )
+    parser.add_argument(
+        "--template",
+        required=True,
+        help="Name of the source TemplateVM or StandaloneVM to upgrade.",
+    )
+    parser.add_argument(
+        "--new-name",
+        help="Name for the upgraded clone. Defaults to replacing the version "
+        "suffix in the source name (e.g. fedora-41 -> fedora-42).",
+    )
+    parser.add_argument(
+        "--keep-new-on-failure",
+        action="store_true",
+        help="Preserve the half-upgraded clone if the upgrade fails. "
+        "By default the clone is removed and the original remains.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate inputs and print the planned actions; do not clone "
+        "or upgrade anything.",
+    )
+    parser.add_argument(
+        "--log", default="INFO", help="Log level (default: INFO)."
+    )
+    return parser
+
+
+def parse_args(
+    argv: Optional[Sequence[str]] = None,
+    app: Optional[qubesadmin.app.QubesBase] = None,
+) -> Tuple[qubesadmin.tools.QubesArgumentParser, argparse.Namespace]:
+    parser = get_parser()
+    return parser, parser.parse_args(argv, app=app)
+
+
+def setup_logging(level: str) -> logging.Logger:
+    log = logging.getLogger("vm-template-upgrade")
+    log.setLevel(level)
+    # Don't let our messages also flow through the root logger.
+    log.propagate = False
+    # Idempotent: if main() is called more than once in the same process
+    # (embedded use, repeated CLI invocations in tests), skip re-adding
+    # handlers so output isn't duplicated.
+    if log.handlers:
+        return log
+    # Always log to stderr: so user sees progress even when the log file
+    # is unavailable (dev machine without /var/log/qubes, perms issues, etc.).
+    stderr = logging.StreamHandler(sys.stderr)
+    stderr.setFormatter(logging.Formatter("%(message)s"))
+    log.addHandler(stderr)
+    try:
+        handler = logging.FileHandler(LOG_PATH, encoding="utf-8")
+        handler.setFormatter(logging.Formatter(LOG_FORMAT))
+        log.addHandler(handler)
+    except OSError as err:
+        log.warning("Could not open log file %s: %s", LOG_PATH, err)
+    return log
+
+
+# Orchestrator
+
+
+class TemplateUpgrader:
+    """Stateful orchestrator for one source qube upgrade."""
+
+    def __init__(
+        self,
+        app: qubesadmin.app.QubesBase,
+        args: argparse.Namespace,
+        log: logging.Logger,
+    ) -> None:
+        self.app = app
+        self.args = args
+        self.log = log
+        # Populated by validate(). qubesadmin ships no py.typed, so QubesVM
+        # resolves to Any for the type checker; the None default is fine and
+        # these are always set before any method that reads them runs.
+        self.source_vm: qubesadmin.vm.QubesVM = None
+        self.distro = ""
+        self.current_version = ""
+        self.target_version = ""
+        self.new_name = ""
+        # Populated by clone(); stays None until then so rollback() can tell
+        # whether there is anything to remove.
+        self.cloned_qube: qubesadmin.vm.QubesVM = None
+
+    # validation
+
+    def validate(self) -> None:
+        """Run all pre-flight checks. Populates planning attributes.
+
+        Raises ValidationError on any input/setup problem. After this call,
+        self.source_vm / distro / current_version / target_version / new_name
+        are all set and the upgrade can proceed (or be reported via
+        describe_plan() for --dry-run).
+        """
+        self.source_vm = self._resolve_source_qube()
+        self.distro, self.current_version = self._detect_distro()
+        self.target_version = compute_target_version(self.current_version)
+        self.new_name = derive_clone_name(
+            self.source_vm.name,
+            self.current_version,
+            self.target_version,
+            self.args.new_name,
+        )
+        if self.new_name in self.app.domains:
+            raise ValidationError(
+                f"Target name {self.new_name!r} already exists. Remove it "
+                "first or pass a different --new-name."
+            )
+
+    def _resolve_source_qube(self) -> qubesadmin.vm.QubesVM:
+        try:
+            vm = self.app.domains[self.args.template]
+        except KeyError as exc:
+            raise ValidationError(
+                f"No such qube: {self.args.template}"
+            ) from exc
+        if vm.klass not in SUPPORTED_CLASSES:
+            raise ValidationError(
+                f"{vm.name} is a {vm.klass}; only TemplateVMs and "
+                f"StandaloneVMs can be upgraded with this tool."
+            )
+        return vm
+
+    def _detect_distro(self) -> Tuple[str, str]:
+        distro = self.source_vm.features.get("os-distribution")
+        distro_like = self.source_vm.features.get("os-distribution-like", "")
+        version = self.source_vm.features.get("os-version")
+        if not distro or not version:
+            raise ValidationError(
+                f"{self.source_vm.name} is missing os-distribution / "
+                f"os-version features. Start the qube once so the in-VM "
+                f"agent can report them, then retry."
+            )
+        candidates = {distro.lower(), *distro_like.lower().split()}
+        supported = SUPPORTED_DISTROS & candidates
+        if not supported:
+            raise ValidationError(
+                f"Unsupported distro {distro!r}; only Fedora- and "
+                f"Debian-based qubes are supported for now."
+            )
+        return sorted(supported)[0], version
+
+    def describe_plan(self) -> str:
+        return (
+            f"upgrade {self.source_vm.name} "
+            f"({self.distro} {self.current_version}) -> "
+            f"clone {self.new_name} "
+            f"({self.distro} {self.target_version})"
+        )
+
+    # execution
+
+    def clone(self) -> None:
+        """Clone the source qube. Populates self.cloned_qube."""
+        self.log.info("Cloning %s -> %s", self.source_vm.name, self.new_name)
+        self.cloned_qube = self.app.clone_vm(self.source_vm, self.new_name)
+
+    def run_agent(self) -> None:
+        """Run the in-VM upgrade agent inside the clone.
+
+        STUB: replaced in a follow-up commit by a dispatch into a new
+        `version_upgrade(target_version)` method on the existing
+        vmupdate agent (vmupdate/agent/source/{dnf,apt}/), reused via the
+        qrexec transport in qube_connection.py. The VM-side agent must
+        re-detect or verify the distro from inside the qube before running
+        distro-specific upgrade commands.
+        """
+        raise NotImplementedError(
+            f"version-upgrade agent is not implemented yet for "
+            f"{self.cloned_qube.name} -> {self.target_version}"
+        )
+
+    def finalize(self) -> None:
+        """Write post-upgrade qvm-features on the clone.
+
+        TemplateVM: always set template-name (required so qvm-template
+        recognises the upgraded clone as managed) and refresh
+        template-installtime.
+
+        StandaloneVM: rewrite an existing template-name from the old to
+        the new release (e.g. fedora-41 -> fedora-42), keeping the value
+        compatible with qui.utils.check_support()'s EOL_DATES lookup
+        (which strips only -minimal / -xfce, not -standalone or the qube
+        name). We do not invent a template-name for standalones that
+        never had one, and we leave one in place that doesn't carry the
+        current version (can't safely transform).
+        """
+        self.log.info("Updating metadata on %s", self.cloned_qube.name)
+        if self.cloned_qube.klass == "TemplateVM":
+            self.cloned_qube.features["template-name"] = self.cloned_qube.name
+            self.cloned_qube.features["template-installtime"] = datetime.now(
+                tz=timezone.utc
+            ).strftime(DATE_FMT)
+            return
+        old = self.cloned_qube.features.get("template-name")
+        if not old:
+            return
+        if self.current_version not in old:
+            # template-name doesn't carry the current version (custom
+            # value, manual edit) it is safer to leave it alone than to
+            # guess what the user intended.
+            self.log.info(
+                "Leaving standalone template-name=%r untouched "
+                "(no version substring to rewrite)",
+                old,
+            )
+            return
+        new = derive_clone_name(
+            old, self.current_version, self.target_version, None
+        )
+        self.cloned_qube.features["template-name"] = new
+
+    def rollback(self) -> None:
+        """Remove the half-upgraded clone, if any. Safe to call repeatedly."""
+        if self.cloned_qube is None:
+            return
+        self.log.warning("Removing failed clone %s", self.cloned_qube.name)
+        try:
+            del self.app.domains[self.cloned_qube.name]
+        except qubesadmin.exc.QubesException as err:
+            self.log.error(
+                "Could not remove failed clone %s: %s",
+                self.cloned_qube.name,
+                err,
+            )
+
+
+# CLI entry point
+
+
+def main(
+    argv: Optional[Sequence[str]] = None,
+    app: Optional[qubesadmin.app.QubesBase] = None,
+) -> int:
+    parser, args = parse_args(argv, app)
+    log = setup_logging(args.log)
+    upgrader = TemplateUpgrader(args.app, args, log)
+
+    try:
+        upgrader.validate()
+    except ValidationError as err:
+        parser.print_error(str(err))
+        return EXIT.ERR_USAGE
+
+    log.info("Plan: %s", upgrader.describe_plan())
+
+    if args.dry_run:
+        print(
+            f"[dry-run] would clone {upgrader.source_vm.name} -> "
+            f"{upgrader.new_name} and upgrade {upgrader.distro} "
+            f"{upgrader.current_version} -> {upgrader.target_version}"
+        )
+        return EXIT.OK
+
+    try:
+        upgrader.clone()
+    except qubesadmin.exc.QubesException as err:
+        print(f"error: clone failed: {err}", file=sys.stderr)
+        return EXIT.ERR
+
+    try:
+        upgrader.run_agent()
+        upgrader.finalize()
+    except (
+        UpgradeError,
+        NotImplementedError,
+        qubesadmin.exc.QubesException,
+    ) as err:
+        log.error("Upgrade failed: %s", err)
+        if not args.keep_new_on_failure:
+            upgrader.rollback()
+        else:
+            log.info(
+                "Leaving clone %s in place (--keep-new-on-failure).",
+                upgrader.cloned_qube.name,
+            )
+        print(f"error: {err}", file=sys.stderr)
+        return EXIT.ERR
+
+    label = (
+        "template"
+        if upgrader.cloned_qube.klass == "TemplateVM"
+        else "standalone"
+    )
+    print(f"Upgrade complete. New {label}: {upgrader.cloned_qube.name}")
+    print(f"Original qube {upgrader.source_vm.name} is untouched.")
+    return EXIT.OK
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/vmupdate/template_upgrade.py
+++ b/vmupdate/template_upgrade.py
@@ -255,14 +255,18 @@ class TemplateUpgrader:
                 f"os-version features. Start the qube once so the in-VM "
                 f"agent can report them, then retry."
             )
-        candidates = {distro.lower(), *distro_like.lower().split()}
-        supported = SUPPORTED_DISTROS & candidates
-        if not supported:
+        # os-distribution takes priority over os-distribution-like, whose
+        # entries are already ordered by closeness (cf. ID_LIKE in os-release)
+        candidates = [distro.lower(), *distro_like.lower().split()]
+        supported = next(
+            (c for c in candidates if c in SUPPORTED_DISTROS), None
+        )
+        if supported is None:
             raise ValidationError(
                 f"Unsupported distro {distro!r}; supported distro families "
                 f"are: {', '.join(d.capitalize() for d in sorted(SUPPORTED_DISTROS))}."
             )
-        return sorted(supported)[0], version
+        return supported, version
 
     def describe_plan(self) -> str:
         return (
@@ -403,7 +407,6 @@ def main(
 
     try:
         upgrader.run_agent()
-        upgrader.finalize()
     except (
         UpgradeError,
         NotImplementedError,
@@ -419,6 +422,19 @@ def main(
             )
         print(f"error: {err}", file=sys.stderr)
         return EXIT.ERR
+
+    # the OS upgrade succeeded: a metadata-write hiccup must not roll the
+    # upgraded clone back, only tell the user what to stamp manually
+    try:
+        upgrader.finalize()
+    except qubesadmin.exc.QubesException as err:
+        log.warning("Could not write post-upgrade features: %s", err)
+        print(
+            f"warning: {upgrader.cloned_qube.name} was upgraded, but "
+            f"writing its template-* features failed: {err}. Set them "
+            f"manually with qvm-features.",
+            file=sys.stderr,
+        )
 
     label = upgrader.cloned_qube.klass.lower().removesuffix("vm")
     print(f"Upgrade complete. New {label}: {upgrader.cloned_qube.name}")

--- a/vmupdate/template_upgrade.py
+++ b/vmupdate/template_upgrade.py
@@ -1,28 +1,23 @@
 #!/usr/bin/python3
 """
-qvm-template-upgrade — perform an N -> N+1 distro version upgrade of a qube
+qvm-template-upgrade — upgrade a qube to the next distro release.
 
 Workflow:
     1. Validate that --template names an existing TemplateVM or StandaloneVM.
-    2. Read os-distribution / os-version from qvm-features.
-    3. Compute the target version as os-version + 1 (N -> N+1 is the
-       only supported scope; multi-hop is rejected by construction).
-    4. Clone the qube to a new name derived from the target version.
-    5. Run the in-VM version-upgrade agent inside the clone
-        (reuses the vmupdate qrexec transport — currently stubbed).
-    6. On success: update template metadata features on the clone.
-    7. On failure: remove the half-upgraded clone unless
-       --keep-new-on-failure.
+    2. Compute the target as os-version + 1 (only consecutive upgrades).
+    3. Clone the qube to a new name derived from the target version.
+    4. Run the in-VM version-upgrade agent inside the clone.
+    5. On success, update template metadata on the clone.
+    6. On failure, remove the clone unless --keep-new-on-failure.
 
-The original qube is never touched by this tool. AppVMs based on a source
-template continue to use it until the user manually switches them and
-uninstalls the old template.
+The original qube is never touched, so it stays available as the fallback.
 """
 
 import argparse
 import logging
 import sys
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Optional, Sequence, Tuple
 
 import qubesadmin
@@ -31,7 +26,10 @@ import qubesadmin.exc
 import qubesadmin.tools
 import qubesadmin.vm
 
+from vmupdate.agent.source.args import AgentArgs
 from vmupdate.agent.source.common.exit_codes import EXIT
+from vmupdate.agent.source.status import FormatedLine
+from vmupdate.update_manager import update_qube
 
 LOG_PATH = "/var/log/qubes/qvm-template-upgrade.log"
 LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
@@ -48,6 +46,24 @@ class UpgradeError(Exception):
 
 class ValidationError(Exception):
     """Invalid user input or unsupported source qube."""
+
+
+class _AgentOutput:
+    """Minimal status sink that logs the agent's output for a single qube.
+
+    Replaces the bulk updater's multiprocessing progress queue, which we
+    don't need when upgrading exactly one qube synchronously.
+    """
+
+    def __init__(self, log: logging.Logger) -> None:
+        self.log = log
+
+    def put(self, item) -> None:
+        # The transport streams agent output as FormatedLine objects; forward
+        # those to the log and drop the StatusInfo progress ticks, which need
+        # the bulk updater's progress bar to mean anything.
+        if isinstance(item, (str, FormatedLine)):
+            self.log.info("%s", item)
 
 
 def compute_target_version(current: str) -> str:
@@ -243,8 +259,8 @@ class TemplateUpgrader:
         supported = SUPPORTED_DISTROS & candidates
         if not supported:
             raise ValidationError(
-                f"Unsupported distro {distro!r}; only Fedora- and "
-                f"Debian-based qubes are supported for now."
+                f"Unsupported distro {distro!r}; supported distro families "
+                f"are: {', '.join(d.capitalize() for d in sorted(SUPPORTED_DISTROS))}."
             )
         return sorted(supported)[0], version
 
@@ -264,59 +280,70 @@ class TemplateUpgrader:
         self.cloned_qube = self.app.clone_vm(self.source_vm, self.new_name)
 
     def run_agent(self) -> None:
-        """Run the in-VM upgrade agent inside the clone.
+        """Run the in-VM version-upgrade agent inside the clone.
 
-        STUB: replaced in a follow-up commit by a dispatch into a new
-        `version_upgrade(target_version)` method on the existing
-        vmupdate agent (vmupdate/agent/source/{dnf,apt}/), reused via the
-        qrexec transport in qube_connection.py. The VM-side agent must
-        re-detect or verify the distro from inside the qube before running
-        distro-specific upgrade commands.
+        Reuses the vmupdate qrexec transport (``update_qube``) with a minimal
+        status sink instead of the bulk updater's progress bar. A non-zero
+        agent result becomes an UpgradeError so main() rolls the clone back.
         """
-        raise NotImplementedError(
-            f"version-upgrade agent is not implemented yet for "
-            f"{self.cloned_qube.name} -> {self.target_version}"
+        agent_args = self._build_agent_args()
+        status_notifier = _AgentOutput(self.log)
+        termination = SimpleNamespace(value=False)
+
+        self.log.info(
+            "Running version-upgrade agent in %s (-> %s)",
+            self.cloned_qube.name,
+            self.target_version,
         )
+        _name, result = update_qube(
+            self.cloned_qube,
+            agent_args,
+            show_progress=True,
+            status_notifier=status_notifier,
+            termination=termination,
+            dom0=False,
+        )
+        if result.code != EXIT.OK:
+            raise UpgradeError(
+                f"in-VM version-upgrade agent failed for "
+                f"{self.cloned_qube.name} (exit code {result.code}); "
+                f"see /var/log/qubes/update-{self.cloned_qube.name}.log"
+            )
+
+    def _build_agent_args(self) -> argparse.Namespace:
+        """Build the entrypoint args for a version-upgrade agent run.
+
+        Reuse the agent's parser for proper defaults and set only the target
+        version; display_name is unused with our private sink.
+        """
+        parser = argparse.ArgumentParser()
+        AgentArgs.add_arguments(parser)
+        agent_args = parser.parse_args(
+            [
+                "--version-upgrade",
+                self.target_version,
+                "--log",
+                self.args.log,
+            ]
+        )
+        agent_args.display_name = None
+        return agent_args
 
     def finalize(self) -> None:
         """Write post-upgrade qvm-features on the clone.
 
-        TemplateVM: always set template-name (required so qvm-template
-        recognises the upgraded clone as managed) and refresh
-        template-installtime.
-
-        StandaloneVM: rewrite an existing template-name from the old to
-        the new release (e.g. fedora-41 -> fedora-42), keeping the value
-        compatible with qui.utils.check_support()'s EOL_DATES lookup
-        (which strips only -minimal / -xfce, not -standalone or the qube
-        name). We do not invent a template-name for standalones that
-        never had one, and we leave one in place that doesn't carry the
-        current version (can't safely transform).
+        Only TemplateVMs are touched: template-name marks the clone as
+        managed by qvm-template and template-installtime is refreshed.
+        StandaloneVMs are outside qvm-template's management model, so their
+        template-* features are left as inherited.
         """
+        if self.cloned_qube.klass != "TemplateVM":
+            return
         self.log.info("Updating metadata on %s", self.cloned_qube.name)
-        if self.cloned_qube.klass == "TemplateVM":
-            self.cloned_qube.features["template-name"] = self.cloned_qube.name
-            self.cloned_qube.features["template-installtime"] = datetime.now(
-                tz=timezone.utc
-            ).strftime(DATE_FMT)
-            return
-        old = self.cloned_qube.features.get("template-name")
-        if not old:
-            return
-        if self.current_version not in old:
-            # template-name doesn't carry the current version (custom
-            # value, manual edit) it is safer to leave it alone than to
-            # guess what the user intended.
-            self.log.info(
-                "Leaving standalone template-name=%r untouched "
-                "(no version substring to rewrite)",
-                old,
-            )
-            return
-        new = derive_clone_name(
-            old, self.current_version, self.target_version, None
-        )
-        self.cloned_qube.features["template-name"] = new
+        self.cloned_qube.features["template-name"] = self.cloned_qube.name
+        self.cloned_qube.features["template-installtime"] = datetime.now(
+            tz=timezone.utc
+        ).strftime(DATE_FMT)
 
     def rollback(self) -> None:
         """Remove the half-upgraded clone, if any. Safe to call repeatedly."""
@@ -324,6 +351,14 @@ class TemplateUpgrader:
             return
         self.log.warning("Removing failed clone %s", self.cloned_qube.name)
         try:
+            # The clone is discarded after a failed upgrade, so kill it
+            # immediately instead of waiting for a graceful shutdown. kill()
+            # already no-ops with QubesVMNotStartedError when the clone has
+            # halted, so swallow that and delete it regardless.
+            try:
+                self.cloned_qube.kill()
+            except qubesadmin.exc.QubesVMNotStartedError:
+                pass
             del self.app.domains[self.cloned_qube.name]
         except qubesadmin.exc.QubesException as err:
             self.log.error(
@@ -385,11 +420,7 @@ def main(
         print(f"error: {err}", file=sys.stderr)
         return EXIT.ERR
 
-    label = (
-        "template"
-        if upgrader.cloned_qube.klass == "TemplateVM"
-        else "standalone"
-    )
+    label = upgrader.cloned_qube.klass.lower().removesuffix("vm")
     print(f"Upgrade complete. New {label}: {upgrader.cloned_qube.name}")
     print(f"Original qube {upgrader.source_vm.name} is untouched.")
     return EXIT.OK

--- a/vmupdate/template_upgrade.py
+++ b/vmupdate/template_upgrade.py
@@ -312,13 +312,13 @@ class TemplateUpgrader:
         self.args = args
         self.log = log
         # Set by validate() before use.
-        self.source_vm: qubesadmin.vm.QubesVM = None
+        self.source_vm: Optional[qubesadmin.vm.QubesVM] = None
         self.distro = ""
         self.current_version = ""
         self.target_version = ""
         self.new_name = ""
         # Set by clone() for rollback.
-        self.cloned_qube: qubesadmin.vm.QubesVM = None
+        self.cloned_qube: Optional[qubesadmin.vm.QubesVM] = None
 
     # validation
 
@@ -354,6 +354,7 @@ class TemplateUpgrader:
         return vm
 
     def _detect_distro(self) -> Tuple[str, str]:
+        assert self.source_vm is not None  # set by validate()
         distro = self.source_vm.features.get("os-distribution")
         distro_like = self.source_vm.features.get("os-distribution-like", "")
         version = self.source_vm.features.get("os-version")
@@ -385,6 +386,7 @@ class TemplateUpgrader:
         )
 
     def describe_plan(self) -> str:
+        assert self.source_vm is not None  # set by validate()
         return (
             f"upgrade {self.source_vm.name} "
             f"({self.distro} {self.current_version}) -> "
@@ -396,6 +398,7 @@ class TemplateUpgrader:
 
     def clone(self) -> None:
         """Clone the source qube. Populates self.cloned_qube."""
+        assert self.source_vm is not None  # set by validate()
         self.log.info("Cloning %s -> %s", self.source_vm.name, self.new_name)
         self.cloned_qube = self.app.clone_vm(self.source_vm, self.new_name)
 
@@ -406,6 +409,7 @@ class TemplateUpgrader:
         The upgrade briefly holds both releases' packages, which can
         trip the 90% threshold. This may bring unnecesarry panic for users.
         """
+        assert self.cloned_qube is not None  # set by clone()
         try:
             prior = self.cloned_qube.features.get(DISK_SPACE_NOTIFY_FEATURE)
             self.cloned_qube.features[DISK_SPACE_NOTIFY_FEATURE] = "1"
@@ -430,6 +434,7 @@ class TemplateUpgrader:
 
     def run_agent(self) -> None:
         """Run the version-upgrade agent inside the clone."""
+        assert self.cloned_qube is not None  # set by clone()
         agent_args = self._build_agent_args()
         # Print the milestone before creating the progress bar.
         self.log.info(
@@ -485,6 +490,8 @@ class TemplateUpgrader:
 
     def finalize(self) -> None:
         """Refresh metadata for an upgraded TemplateVM."""
+        assert self.cloned_qube is not None  # set by clone()
+        assert self.source_vm is not None  # set by validate()
         # The in-VM agent verified the new release; make sure dom0 metadata
         # reflects it even if qubes.PostInstall's feature refresh failed.
         if self.cloned_qube.features.get("os-version") != self.target_version:
@@ -557,9 +564,12 @@ def main(
 
     log.info("Plan: %s", upgrader.describe_plan())
 
+    source_vm = upgrader.source_vm
+    assert source_vm is not None  # set by validate()
+
     if args.dry_run:
         print(
-            f"[dry-run] would clone {upgrader.source_vm.name} -> "
+            f"[dry-run] would clone {source_vm.name} -> "
             f"{upgrader.new_name} and upgrade {upgrader.distro} "
             f"{upgrader.current_version} -> {upgrader.target_version}"
         )
@@ -571,6 +581,8 @@ def main(
         except qubesadmin.exc.QubesException as err:
             print(f"error: clone failed: {err}", file=sys.stderr)
             return EXIT.ERR
+        cloned_qube = upgrader.cloned_qube
+        assert cloned_qube is not None  # set by clone()
 
         try:
             upgrader.run_agent()
@@ -581,7 +593,7 @@ def main(
             else:
                 log.info(
                     "Leaving clone %s in place (--keep-new-on-failure).",
-                    upgrader.cloned_qube.name,
+                    cloned_qube.name,
                 )
             print(f"error: {err}", file=sys.stderr)
             return EXIT.ERR
@@ -592,15 +604,15 @@ def main(
         except qubesadmin.exc.QubesException as err:
             log.warning("Could not write post-upgrade features: %s", err)
             print(
-                f"warning: {upgrader.cloned_qube.name} was upgraded, but "
+                f"warning: {cloned_qube.name} was upgraded, but "
                 f"writing its template-* features failed: {err}. Set them "
                 f"manually with qvm-features.",
                 file=sys.stderr,
             )
 
-        label = upgrader.cloned_qube.klass.lower().removesuffix("vm")
-        print(f"Upgrade complete. New {label}: {upgrader.cloned_qube.name}")
-        print(f"Original qube {upgrader.source_vm.name} is untouched.")
+        label = cloned_qube.klass.lower().removesuffix("vm")
+        print(f"Upgrade complete. New {label}: {cloned_qube.name}")
+        print(f"Original qube {source_vm.name} is untouched.")
         return EXIT.OK
     except KeyboardInterrupt:
         log.error("Interrupted; clone %s may remain.", upgrader.new_name)

--- a/vmupdate/template_upgrade.py
+++ b/vmupdate/template_upgrade.py
@@ -213,9 +213,7 @@ def derive_clone_name(
         return f"{source_name}-{target_version}"
     last = matches[-1]
     return (
-        source_name[: last.start()]
-        + target_version
-        + source_name[last.end() :]
+        source_name[: last.start()] + target_version + source_name[last.end() :]
     )
 
 
@@ -424,9 +422,7 @@ class TemplateUpgrader:
                 if prior is None:
                     del self.cloned_qube.features[DISK_SPACE_NOTIFY_FEATURE]
                 else:
-                    self.cloned_qube.features[DISK_SPACE_NOTIFY_FEATURE] = (
-                        prior
-                    )
+                    self.cloned_qube.features[DISK_SPACE_NOTIFY_FEATURE] = prior
             except (KeyError, qubesadmin.exc.QubesException) as err:
                 self.log.warning(
                     "could not restore disk space warning: %s", err

--- a/vmupdate/template_upgrade.py
+++ b/vmupdate/template_upgrade.py
@@ -2,6 +2,7 @@
 """Upgrade a clone to the next distro release."""
 
 import argparse
+import contextlib
 import logging
 import re
 import sys
@@ -9,7 +10,7 @@ import threading
 import time
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from typing import Optional, Sequence, Tuple
+from typing import Iterator, Optional, Sequence, Tuple
 
 import qubesadmin
 import qubesadmin.app
@@ -36,6 +37,9 @@ SUPPORTED_CLASSES = {"TemplateVM", "StandaloneVM"}
 DATE_FMT = "%Y-%m-%d %H:%M:%S"
 # Mark templates created by this tool.
 REPONAME = "@qvm-template-upgrade"
+
+# qui-disk-space's per-qube "running out of storage space" warning.
+DISK_SPACE_NOTIFY_FEATURE = "disk-space-not-notify"
 
 
 class UpgradeError(Exception):
@@ -395,6 +399,35 @@ class TemplateUpgrader:
         self.log.info("Cloning %s -> %s", self.source_vm.name, self.new_name)
         self.cloned_qube = self.app.clone_vm(self.source_vm, self.new_name)
 
+    @contextlib.contextmanager
+    def _disk_space_warning_suppressed(self) -> Iterator[None]:
+        """Temporarily suppress qui-disk-space during upgrade.
+
+        The upgrade briefly holds both releases' packages, which can
+        trip the 90% threshold. This may bring unnecesarry panic for users.
+        """
+        try:
+            prior = self.cloned_qube.features.get(DISK_SPACE_NOTIFY_FEATURE)
+            self.cloned_qube.features[DISK_SPACE_NOTIFY_FEATURE] = "1"
+        except qubesadmin.exc.QubesException as err:
+            self.log.warning("could not suppress disk space warning: %s", err)
+            yield
+            return
+        try:
+            yield
+        finally:
+            try:
+                if prior is None:
+                    del self.cloned_qube.features[DISK_SPACE_NOTIFY_FEATURE]
+                else:
+                    self.cloned_qube.features[DISK_SPACE_NOTIFY_FEATURE] = (
+                        prior
+                    )
+            except (KeyError, qubesadmin.exc.QubesException) as err:
+                self.log.warning(
+                    "could not restore disk space warning: %s", err
+                )
+
     def run_agent(self) -> None:
         """Run the version-upgrade agent inside the clone."""
         agent_args = self._build_agent_args()
@@ -414,19 +447,20 @@ class TemplateUpgrader:
         )
         termination = SimpleNamespace(value=False)
 
-        status_notifier.start()
-        try:
-            _name, result = update_qube(
-                self.cloned_qube,
-                agent_args,
-                show_progress=True,
-                status_notifier=status_notifier,
-                termination=termination,
-                dom0=False,
-            )
-        finally:
-            # Finish the bar before any later output.
-            status_notifier.close()
+        with self._disk_space_warning_suppressed():
+            status_notifier.start()
+            try:
+                _name, result = update_qube(
+                    self.cloned_qube,
+                    agent_args,
+                    show_progress=True,
+                    status_notifier=status_notifier,
+                    termination=termination,
+                    dom0=False,
+                )
+            finally:
+                # Finish the bar before any later output.
+                status_notifier.close()
         if result.code != EXIT.OK:
             raise UpgradeError(
                 f"in-VM version-upgrade agent failed for "

--- a/vmupdate/template_upgrade.py
+++ b/vmupdate/template_upgrade.py
@@ -1,0 +1,578 @@
+#!/usr/bin/python3
+"""Upgrade a clone to the next distro release."""
+
+import argparse
+import logging
+import re
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Optional, Sequence, Tuple
+
+import qubesadmin
+import qubesadmin.app
+import qubesadmin.exc
+import qubesadmin.tools
+import qubesadmin.vm
+
+from tqdm import tqdm
+
+from vmupdate.agent.source.args import AgentArgs
+from vmupdate.agent.source.common.exit_codes import EXIT
+from vmupdate.agent.source.status import FormatedLine, StatusInfo
+from vmupdate.update_manager import update_qube
+
+LOG_PATH = "/var/log/qubes/qvm-template-upgrade.log"
+LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
+# Separate logger so agent output reaches the log file but not stderr;
+# _AgentOutput streams it to the terminal itself.
+AGENT_LOGGER = "vm-template-upgrade.agent"
+
+SUPPORTED_DISTROS = {"fedora", "debian"}
+SUPPORTED_CLASSES = {"TemplateVM", "StandaloneVM"}
+
+DATE_FMT = "%Y-%m-%d %H:%M:%S"
+# Mark templates created by this tool.
+REPONAME = "@qvm-template-upgrade"
+
+
+class UpgradeError(Exception):
+    """Failure during the upgrade run itself."""
+
+
+class ValidationError(Exception):
+    """Invalid user input or unsupported source qube."""
+
+
+def make_progress_bar(description: str) -> Optional[tqdm]:
+    """Build a terminal progress bar when stderr is interactive."""
+    if not sys.stderr.isatty():
+        return None
+    return tqdm(
+        total=100.0,
+        desc=description,
+        file=sys.stderr,
+        # Resize with the terminal during long upgrades.
+        dynamic_ncols=True,
+        bar_format="{desc} {percentage:5.1f}% |{bar}| [{elapsed}]{postfix}",
+    )
+
+
+def format_quiet_time(seconds: float) -> str:
+    """Format elapsed quiet time for the progress bar."""
+    minutes, secs = divmod(int(seconds), 60)
+    if minutes:
+        return f"{minutes}m{secs:02d}s"
+    return f"{secs}s"
+
+
+class _AgentOutput:
+    """Stream agent output above one progress bar."""
+
+    #: Heartbeat refresh interval in seconds.
+    HEARTBEAT_INTERVAL = 1.0
+    #: Inactivity threshold before showing wait duration.
+    QUIET_AFTER = 30.0
+
+    def __init__(
+        self,
+        log: logging.Logger,
+        progress_bar: Optional[tqdm] = None,
+    ) -> None:
+        self.log = log
+        self.progress_bar = progress_bar
+        # The heartbeat thread and put() both draw on the bar.
+        self._bar_lock = threading.Lock()
+        self._last_advance = time.monotonic()
+        self._stop_heartbeat = threading.Event()
+        self._heartbeat: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        """Start the progress heartbeat when a bar is enabled."""
+        if self.progress_bar is None or self._heartbeat is not None:
+            return
+        self._heartbeat = threading.Thread(
+            target=self._beat, name="upgrade-progress-heartbeat", daemon=True
+        )
+        self._heartbeat.start()
+
+    def _beat(self) -> None:
+        while not self._stop_heartbeat.wait(self.HEARTBEAT_INTERVAL):
+            with self._bar_lock:
+                if self.progress_bar is None:
+                    return
+                try:
+                    self.progress_bar.set_postfix_str(
+                        self._quiet_note(), refresh=False
+                    )
+                    self.progress_bar.refresh()
+                except Exception:  # pylint: disable=broad-except
+                    # Progress rendering must not interrupt the upgrade.
+                    self.log.debug("progress heartbeat stopped", exc_info=True)
+                    return
+
+    def _quiet_note(self) -> str:
+        """Return the waiting time after progress stalls."""
+        quiet = time.monotonic() - self._last_advance
+        if quiet < self.QUIET_AFTER:
+            return ""
+        return f"waiting {format_quiet_time(quiet)}"
+
+    def put(self, item) -> None:
+        # The transport streams agent output as FormatedLine objects.
+        if isinstance(item, (str, FormatedLine)):
+            self.log.info("%s", item)
+            with self._bar_lock:
+                if self.progress_bar is not None:
+                    # tqdm reprints the bar below the written line.
+                    self.progress_bar.write(str(item))
+                else:
+                    print(item, flush=True)
+        elif isinstance(item, StatusInfo):
+            # Keep progress history in the debug log.
+            self.log.debug("%s progress: %s", item.qname, item.info)
+            # done/pending carry a FinalStatus or None, not a percent
+            if self.progress_bar is not None and isinstance(
+                item.info, (int, float)
+            ):
+                with self._bar_lock:
+                    if self.progress_bar is None:
+                        return
+                    advance = float(item.info) - self.progress_bar.n
+                    if advance > 0:
+                        # Clear the stale waiting note.
+                        self._last_advance = time.monotonic()
+                        self.progress_bar.set_postfix_str("", refresh=False)
+                        self.progress_bar.update(advance)
+
+    def close(self) -> None:
+        """Stop the heartbeat and finish the progress line."""
+        self._stop_heartbeat.set()
+        heartbeat, self._heartbeat = self._heartbeat, None
+        if heartbeat is not None:
+            heartbeat.join(timeout=self.HEARTBEAT_INTERVAL * 2)
+        if not self._bar_lock.acquire(timeout=self.HEARTBEAT_INTERVAL * 2):
+            self.log.debug("progress bar busy; leaving its line unfinished")
+            return
+        try:
+            if self.progress_bar is not None:
+                self.progress_bar.set_postfix_str("", refresh=False)
+                self.progress_bar.close()
+                self.progress_bar = None
+        finally:
+            self._bar_lock.release()
+
+
+def compute_target_version(current: str) -> str:
+    """Return current + 1 as the target distro version.
+
+    Non-integer versions are rejected here.
+    """
+    try:
+        current_n = int(current)
+    except ValueError as exc:
+        raise ValidationError(
+            f"Non-numeric distro version {current!r}; multi-component "
+            f"versions (e.g. Debian point releases) are not yet supported "
+            f"by this tool."
+        ) from exc
+    return str(current_n + 1)
+
+
+def derive_clone_name(
+    source_name: str,
+    current_version: str,
+    target_version: str,
+    override: Optional[str],
+) -> str:
+    """Replace the version in the source name with the target version.
+
+    Examples:
+        fedora-41, 41 -> 42  =>  fedora-42
+
+        fedora-41-minimal, 41 -> 42  =>  fedora-42-minimal
+
+        custom, 41 -> 42  =>  custom-42
+
+        debian-121, 12 -> 13  =>  debian-121-13 (no match inside digit runs)
+    """
+    if override:
+        return override
+    # Replace only the last occurrence (e.g. fedora-41-extras-41 stays
+    # sane), and only at digit boundaries (debian-121 has no "12").
+    matches = list(
+        re.finditer(rf"(?<!\d){re.escape(current_version)}(?!\d)", source_name)
+    )
+    if not matches:
+        return f"{source_name}-{target_version}"
+    last = matches[-1]
+    return (
+        source_name[: last.start()]
+        + target_version
+        + source_name[last.end() :]
+    )
+
+
+# Argument parsing / logging
+
+
+def get_parser() -> qubesadmin.tools.QubesArgumentParser:
+    parser = qubesadmin.tools.QubesArgumentParser(
+        prog="qvm-template-upgrade",
+        description="Upgrade a TemplateVM or StandaloneVM to the next distro "
+        "version.",
+        # Avoid qubesadmin package metadata lookup when run from PYTHONPATH.
+        version="",
+    )
+    parser.add_argument(
+        "--template",
+        required=True,
+        help="Name of the source TemplateVM or StandaloneVM to upgrade.",
+    )
+    parser.add_argument(
+        "--new-name",
+        help="Name for the upgraded clone. Defaults to replacing the version "
+        "suffix in the source name (e.g. fedora-41 -> fedora-42).",
+    )
+    parser.add_argument(
+        "--keep-new-on-failure",
+        action="store_true",
+        help="Preserve the half-upgraded clone if the upgrade fails. "
+        "By default the clone is removed and the original remains.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate inputs and print the planned actions; do not clone "
+        "or upgrade anything.",
+    )
+    parser.add_argument(
+        "--log",
+        default="INFO",
+        type=str.upper,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Log level (default: INFO).",
+    )
+    return parser
+
+
+def parse_args(
+    argv: Optional[Sequence[str]] = None,
+    app: Optional[qubesadmin.app.QubesBase] = None,
+) -> Tuple[qubesadmin.tools.QubesArgumentParser, argparse.Namespace]:
+    parser = get_parser()
+    return parser, parser.parse_args(argv, app=app)
+
+
+def setup_logging(level: str) -> logging.Logger:
+    log = logging.getLogger("vm-template-upgrade")
+    log.setLevel(level)
+    # Keep agent output out of the terminal.
+    agent_log = logging.getLogger(AGENT_LOGGER)
+    agent_log.setLevel(level)
+    # Do not propagate agent output to the main logger.
+    log.propagate = False
+    agent_log.propagate = False
+    # Avoid duplicate handlers when main() runs again.
+    if log.handlers:
+        return log
+    # Keep milestones visible if the log file is unavailable.
+    stderr = logging.StreamHandler(sys.stderr)
+    stderr.setFormatter(logging.Formatter("%(message)s"))
+    log.addHandler(stderr)
+    try:
+        handler = logging.FileHandler(LOG_PATH, encoding="utf-8")
+        handler.setFormatter(logging.Formatter(LOG_FORMAT))
+        log.addHandler(handler)
+        agent_log.addHandler(handler)
+    except OSError as err:
+        log.warning("Could not open log file %s: %s", LOG_PATH, err)
+    return log
+
+
+# Upgrade manager
+
+
+class TemplateUpgrader:
+    """Manages the upgrade workflow for a single source qube."""
+
+    def __init__(
+        self,
+        app: qubesadmin.app.QubesBase,
+        args: argparse.Namespace,
+        log: logging.Logger,
+    ) -> None:
+        self.app = app
+        self.args = args
+        self.log = log
+        # Set by validate() before use.
+        self.source_vm: qubesadmin.vm.QubesVM = None
+        self.distro = ""
+        self.current_version = ""
+        self.target_version = ""
+        self.new_name = ""
+        # Set by clone() for rollback.
+        self.cloned_qube: qubesadmin.vm.QubesVM = None
+
+    # validation
+
+    def validate(self) -> None:
+        """Validate inputs and prepare the upgrade plan."""
+        self.source_vm = self._resolve_source_qube()
+        self.distro, self.current_version = self._detect_distro()
+        self.target_version = compute_target_version(self.current_version)
+        self.new_name = derive_clone_name(
+            self.source_vm.name,
+            self.current_version,
+            self.target_version,
+            self.args.new_name,
+        )
+        if self.new_name in self.app.domains:
+            raise ValidationError(
+                f"Target name {self.new_name!r} already exists. Remove it "
+                "first or pass a different --new-name."
+            )
+
+    def _resolve_source_qube(self) -> qubesadmin.vm.QubesVM:
+        try:
+            vm = self.app.domains[self.args.template]
+        except KeyError as exc:
+            raise ValidationError(
+                f"No such qube: {self.args.template}"
+            ) from exc
+        if vm.klass not in SUPPORTED_CLASSES:
+            raise ValidationError(
+                f"{vm.name} is a {vm.klass}; only TemplateVMs and "
+                f"StandaloneVMs can be upgraded with this tool."
+            )
+        return vm
+
+    def _detect_distro(self) -> Tuple[str, str]:
+        distro = self.source_vm.features.get("os-distribution")
+        distro_like = self.source_vm.features.get("os-distribution-like", "")
+        version = self.source_vm.features.get("os-version")
+        if not distro or not version:
+            raise ValidationError(
+                f"{self.source_vm.name} is missing os-distribution / "
+                f"os-version features. Start the qube once so the in-VM "
+                f"agent can report them, then retry."
+            )
+        # Only os-distribution itself counts: a derivative (matched via
+        # os-distribution-like) has its own version scheme, so the parent
+        # family's target = version + 1 would be meaningless for it.
+        distro_lower = distro.lower()
+        if distro_lower in SUPPORTED_DISTROS:
+            return distro_lower, version
+        family = next(
+            (c for c in distro_like.lower().split() if c in SUPPORTED_DISTROS),
+            None,
+        )
+        if family is not None:
+            raise ValidationError(
+                f"{self.source_vm.name} is a {distro} derivative; its own "
+                f"version numbering does not match {family}'s releases, so "
+                f"it cannot be upgraded with this tool."
+            )
+        raise ValidationError(
+            f"Unsupported distro {distro!r}; supported distro families "
+            f"are: {', '.join(d.capitalize() for d in sorted(SUPPORTED_DISTROS))}."
+        )
+
+    def describe_plan(self) -> str:
+        return (
+            f"upgrade {self.source_vm.name} "
+            f"({self.distro} {self.current_version}) -> "
+            f"clone {self.new_name} "
+            f"({self.distro} {self.target_version})"
+        )
+
+    # execution
+
+    def clone(self) -> None:
+        """Clone the source qube. Populates self.cloned_qube."""
+        self.log.info("Cloning %s -> %s", self.source_vm.name, self.new_name)
+        self.cloned_qube = self.app.clone_vm(self.source_vm, self.new_name)
+
+    def run_agent(self) -> None:
+        """Run the version-upgrade agent inside the clone."""
+        agent_args = self._build_agent_args()
+        # Print the milestone before creating the progress bar.
+        self.log.info(
+            "Running version-upgrade agent in %s (-> %s)",
+            self.cloned_qube.name,
+            self.target_version,
+        )
+        status_notifier = _AgentOutput(
+            logging.getLogger(AGENT_LOGGER),
+            progress_bar=make_progress_bar(
+                f"{self.cloned_qube.name} "
+                f"({self.distro} {self.current_version} "
+                f"-> {self.target_version})"
+            ),
+        )
+        termination = SimpleNamespace(value=False)
+
+        status_notifier.start()
+        try:
+            _name, result = update_qube(
+                self.cloned_qube,
+                agent_args,
+                show_progress=True,
+                status_notifier=status_notifier,
+                termination=termination,
+                dom0=False,
+            )
+        finally:
+            # Finish the bar before any later output.
+            status_notifier.close()
+        if result.code != EXIT.OK:
+            raise UpgradeError(
+                f"in-VM version-upgrade agent failed for "
+                f"{self.cloned_qube.name} (exit code {result.code}); "
+                f"see /var/log/qubes/update-{self.cloned_qube.name}.log"
+            )
+
+    def _build_agent_args(self) -> argparse.Namespace:
+        """Build arguments for a version-upgrade agent run."""
+        parser = argparse.ArgumentParser()
+        AgentArgs.add_arguments(parser)
+        agent_args = parser.parse_args(
+            [
+                "--version-upgrade",
+                self.target_version,
+                "--log",
+                self.args.log,
+            ]
+        )
+        agent_args.display_name = None
+        return agent_args
+
+    def finalize(self) -> None:
+        """Refresh metadata for an upgraded TemplateVM."""
+        # The in-VM agent verified the new release; make sure dom0 metadata
+        # reflects it even if qubes.PostInstall's feature refresh failed.
+        if self.cloned_qube.features.get("os-version") != self.target_version:
+            self.cloned_qube.features["os-version"] = self.target_version
+        if self.cloned_qube.klass != "TemplateVM":
+            return
+        self.log.info("Updating metadata on %s", self.cloned_qube.name)
+        self.cloned_qube.features["template-name"] = self.cloned_qube.name
+        now = datetime.now(tz=timezone.utc).strftime(DATE_FMT)
+        self.cloned_qube.features["template-installtime"] = now
+        # The clone filesystem was produced by this upgrade.
+        self.cloned_qube.features["template-buildtime"] = now
+        # Record the tool: this clone came from neither a repo nor an RPM.
+        self.cloned_qube.features["template-reponame"] = REPONAME
+        # Preserve inherited EVR metadata. qvm-template uses it for package
+        # comparisons, so generating a value would give an invalid ordering.
+        # Replace the inherited source name but keep all other user text.
+        for feature in ("template-summary", "template-description"):
+            value = self.cloned_qube.features.get(feature, "")
+            if self.source_vm.name in value:
+                self.cloned_qube.features[feature] = value.replace(
+                    self.source_vm.name, self.cloned_qube.name
+                )
+
+    def rollback(self) -> None:
+        """Remove the half-upgraded clone, if any. Safe to call repeatedly."""
+        if self.cloned_qube is None:
+            return
+        self.log.warning("Removing failed clone %s", self.cloned_qube.name)
+        try:
+            # Discard the failed clone immediately; kill() no-ops when the
+            # clone has already halted.
+            try:
+                self.cloned_qube.kill()
+            except qubesadmin.exc.QubesVMNotStartedError:
+                pass
+            # kill() returns before teardown finishes; deleting a domain
+            # that is not yet halted fails, so wait briefly for it.
+            deadline = time.monotonic() + 30
+            while (
+                self.cloned_qube.get_power_state() != "Halted"
+                and time.monotonic() < deadline
+            ):
+                time.sleep(0.5)
+            del self.app.domains[self.cloned_qube.name]
+        except qubesadmin.exc.QubesException as err:
+            self.log.error(
+                "Could not remove failed clone %s: %s",
+                self.cloned_qube.name,
+                err,
+            )
+
+
+# CLI entry point
+
+
+def main(
+    argv: Optional[Sequence[str]] = None,
+    app: Optional[qubesadmin.app.QubesBase] = None,
+) -> int:
+    parser, args = parse_args(argv, app)
+    log = setup_logging(args.log)
+    upgrader = TemplateUpgrader(args.app, args, log)
+
+    try:
+        upgrader.validate()
+    except ValidationError as err:
+        parser.print_error(str(err))
+        return EXIT.ERR_USAGE
+
+    log.info("Plan: %s", upgrader.describe_plan())
+
+    if args.dry_run:
+        print(
+            f"[dry-run] would clone {upgrader.source_vm.name} -> "
+            f"{upgrader.new_name} and upgrade {upgrader.distro} "
+            f"{upgrader.current_version} -> {upgrader.target_version}"
+        )
+        return EXIT.OK
+
+    try:
+        try:
+            upgrader.clone()
+        except qubesadmin.exc.QubesException as err:
+            print(f"error: clone failed: {err}", file=sys.stderr)
+            return EXIT.ERR
+
+        try:
+            upgrader.run_agent()
+        except UpgradeError as err:
+            log.error("Upgrade failed: %s", err)
+            if not args.keep_new_on_failure:
+                upgrader.rollback()
+            else:
+                log.info(
+                    "Leaving clone %s in place (--keep-new-on-failure).",
+                    upgrader.cloned_qube.name,
+                )
+            print(f"error: {err}", file=sys.stderr)
+            return EXIT.ERR
+
+        # A metadata failure must not roll back a completed OS upgrade.
+        try:
+            upgrader.finalize()
+        except qubesadmin.exc.QubesException as err:
+            log.warning("Could not write post-upgrade features: %s", err)
+            print(
+                f"warning: {upgrader.cloned_qube.name} was upgraded, but "
+                f"writing its template-* features failed: {err}. Set them "
+                f"manually with qvm-features.",
+                file=sys.stderr,
+            )
+
+        label = upgrader.cloned_qube.klass.lower().removesuffix("vm")
+        print(f"Upgrade complete. New {label}: {upgrader.cloned_qube.name}")
+        print(f"Original qube {upgrader.source_vm.name} is untouched.")
+        return EXIT.OK
+    except KeyboardInterrupt:
+        log.error("Interrupted; clone %s may remain.", upgrader.new_name)
+        print("error: interrupted; the clone may remain.", file=sys.stderr)
+        return EXIT.SIGINT
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/vmupdate/tests/conftest.py
+++ b/vmupdate/tests/conftest.py
@@ -51,6 +51,7 @@ class TestVM:
         self.features = Features(name, app)
         self.shutdown = Mock()
         self.start = Mock()
+        self.kill = Mock()
         for key, value in kwargs.items():
             setattr(self, key, value)
 

--- a/vmupdate/tests/conftest.py
+++ b/vmupdate/tests/conftest.py
@@ -51,11 +51,16 @@ class TestVM:
         self.features = Features(name, app)
         self.shutdown = Mock()
         self.start = Mock()
+        self.kill = Mock()
         for key, value in kwargs.items():
             setattr(self, key, value)
 
     def is_running(self):
         return self.running
+
+    def get_power_state(self):
+        # mirrors qubesadmin's power states as far as the tests need
+        return "Running" if self.running else "Halted"
 
     def __str__(self):
         return self.name

--- a/vmupdate/tests/test_qube_connection.py
+++ b/vmupdate/tests/test_qube_connection.py
@@ -18,8 +18,11 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
 # USA.
+import io
+
 from unittest.mock import Mock, patch
 
+from vmupdate.agent.source.status import FormatedLine, StatusInfo
 from vmupdate.qube_connection import QubeConnection
 
 
@@ -93,3 +96,26 @@ def test_do_not_shutdown_if_vm_was_already_running(shutdown_domains):
 
     vm.shutdown.assert_not_called()
     shutdown_domains.assert_not_called()
+
+
+def test_collect_stderr_drops_repeated_final_milestone():
+    """Duplicate 100.0 milestone is not treated as error text."""
+    connection = QubeConnection.__new__(QubeConnection)
+    connection.qube = Mock()
+    connection.qube.name = "fedora-42-xfce"
+    connection.logger = Mock()
+    connection.status_notifier = Mock()
+    proc = Mock()
+    proc.stderr = io.BytesIO(b"50.00\n100.00\n100.00\n42.00\nreal error\n")
+
+    connection._collect_stderr(proc)
+
+    items = [
+        call.args[0] for call in connection.status_notifier.put.call_args_list
+    ]
+    progress = [i.info for i in items if isinstance(i, StatusInfo)]
+    assert progress == [50.0, 100.0]
+    # only the exact repeated 100 milestone is dropped; other numeric
+    # stderr (like the stray "42.00") stays visible
+    errors = [i.message for i in items if isinstance(i, FormatedLine)]
+    assert errors == ["42.00", "real error"]

--- a/vmupdate/tests/test_template_upgrade.py
+++ b/vmupdate/tests/test_template_upgrade.py
@@ -9,6 +9,7 @@ import qubesadmin.exc
 
 from vmupdate import template_upgrade
 from vmupdate.agent.source.common.exit_codes import EXIT
+from vmupdate.agent.source.common.process_result import ProcessResult
 from vmupdate.tests.conftest import TestApp as _TestApp
 from vmupdate.tests.conftest import TestVM as _TestVM
 
@@ -27,6 +28,9 @@ class CloneApp(_TestApp):
         self.clone_calls.append((source_vm.name, new_name))
         clone = _TestVM(new_name, self, klass=source_vm.klass)
         clone.features.update(source_vm.features)
+        # A freshly cloned qube hasn't been started, so rollback() shouldn't
+        # try to force it down. (TestVM defaults running=True.)
+        clone.running = False
         return clone
 
 
@@ -133,7 +137,20 @@ def test_dry_run_does_not_mutate(capsys):
     assert "would clone ubuntu-22 -> ubuntu-23" in capsys.readouterr().out
 
 
-def test_success_applies_metadata(monkeypatch):
+def test_unsupported_distro_message_lists_supported_families(capsys):
+    app = CloneApp()
+    add_template(app, **{"os-distribution": "arch"})
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.ERR_USAGE
+    assert (
+        "supported distro families are: Debian, Fedora"
+        in capsys.readouterr().err
+    )
+
+
+def test_success_applies_metadata(monkeypatch, capsys):
     app = CloneApp()
     add_template(app)
     monkeypatch.setattr(
@@ -143,6 +160,9 @@ def test_success_applies_metadata(monkeypatch):
     retcode = template_upgrade.main(["--template", "fedora-41"], app)
 
     assert retcode == EXIT.OK
+    assert (
+        "Upgrade complete. New template: fedora-42" in capsys.readouterr().out
+    )
     clone = app.domains["fedora-42"]
     assert clone.features["template-name"] == "fedora-42"
     assert clone.features["template-installtime"] != app.domains[
@@ -156,7 +176,7 @@ def test_success_applies_metadata(monkeypatch):
     assert clone.features["os-version"] == "41"
 
 
-def test_standalone_without_template_name_left_alone(monkeypatch):
+def test_standalone_without_template_name_left_alone(monkeypatch, capsys):
     """A standalone that never had template-name doesn't get one invented."""
     app = CloneApp()
     add_standalone(app)
@@ -167,14 +187,19 @@ def test_standalone_without_template_name_left_alone(monkeypatch):
     retcode = template_upgrade.main(["--template", "fedora-41-standalone"], app)
 
     assert retcode == EXIT.OK
+    assert (
+        "Upgrade complete. New standalone: fedora-42-standalone"
+        in capsys.readouterr().out
+    )
     clone = app.domains["fedora-42-standalone"]
     assert clone.klass == "StandaloneVM"
     assert "template-name" not in clone.features
     assert "template-installtime" not in clone.features
 
 
-def test_standalone_with_template_name_refreshed(monkeypatch):
-    """Refresh stale standalone template-name for updater EOL checks."""
+def test_standalone_template_name_left_untouched(monkeypatch):
+    """A standalone's template-* features are never rewritten; the clone
+    keeps whatever it inherited from the source."""
     app = CloneApp()
     add_standalone(app, **{"template-name": "fedora-41"})
     monkeypatch.setattr(
@@ -185,21 +210,54 @@ def test_standalone_with_template_name_refreshed(monkeypatch):
 
     assert retcode == EXIT.OK
     clone = app.domains["fedora-42-standalone"]
-    # check_support() resolves this through EOL_DATES.
-    assert clone.features["template-name"] == "fedora-42"
-    # template-installtime is template-only; standalones don't get one.
+    # The clone inherits the source value; the tool does not touch it.
+    assert clone.features["template-name"] == "fedora-41"
     assert "template-installtime" not in clone.features
 
 
-def test_default_stub_fails_and_cleans_clone(capsys):
+def test_run_agent_success_invokes_transport(monkeypatch):
+    """A successful agent run upgrades the clone (not the source) in
+    single-qube VM mode and tells the agent the exact target release."""
     app = CloneApp()
     add_template(app)
+    captured = {}
+
+    def fake_update_qube(qube, agent_args, **kwargs):
+        captured["qube"] = qube
+        captured["agent_args"] = agent_args
+        captured["kwargs"] = kwargs
+        return qube.name, ProcessResult(EXIT.OK)
+
+    monkeypatch.setattr(template_upgrade, "update_qube", fake_update_qube)
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.OK
+    assert captured["qube"].name == "fedora-42"
+    assert captured["kwargs"]["dom0"] is False
+    assert captured["kwargs"]["show_progress"] is True
+    assert captured["agent_args"].version_upgrade == "42"
+    assert captured["agent_args"].display_name is None
+    # success path still applies post-upgrade metadata
+    assert app.domains["fedora-42"].features["template-name"] == "fedora-42"
+
+
+def test_run_agent_failure_rolls_back_clone(monkeypatch, capsys):
+    """A non-zero agent exit becomes an UpgradeError and the clone is
+    removed (the wired replacement for the old NotImplementedError stub)."""
+    app = CloneApp()
+    add_template(app)
+
+    def fake_update_qube(qube, agent_args, **kwargs):
+        return qube.name, ProcessResult(EXIT.ERR_VM_UPDATE)
+
+    monkeypatch.setattr(template_upgrade, "update_qube", fake_update_qube)
 
     retcode = template_upgrade.main(["--template", "fedora-41"], app)
 
     assert retcode == EXIT.ERR
     assert "fedora-42" not in app.domains
-    assert "not implemented yet" in capsys.readouterr().err
+    assert "version-upgrade agent failed" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(
@@ -276,6 +334,26 @@ def test_main_clone_failure(monkeypatch, capsys):
     assert "clone failed: storage pool full" in capsys.readouterr().err
 
 
+def test_agent_output_forwards_lines_and_drops_status():
+    """FormatedLine output reaches the log; StatusInfo ticks are dropped."""
+    from vmupdate.agent.source.status import (
+        FinalStatus,
+        FormatedLine,
+        StatusInfo,
+    )
+
+    log = Mock()
+    sink = template_upgrade._AgentOutput(log)
+
+    sink.put(FormatedLine("fedora-42", "out", "Downloading packages"))
+    sink.put("fedora-42:err: a plain string line")
+    sink.put(StatusInfo.updating(Mock(name="fedora-42"), 42.0))
+    sink.put(StatusInfo.done(Mock(name="fedora-42"), FinalStatus.SUCCESS))
+
+    # Only the two human-readable lines are logged.
+    assert log.info.call_count == 2
+
+
 def test_rollback_noop_when_no_clone():
     """rollback() before clone() ran is a safe no-op."""
     upgrader = template_upgrade.TemplateUpgrader(CloneApp(), Mock(), Mock())
@@ -303,6 +381,35 @@ def test_rollback_handles_delete_failure():
     upgrader.log.error.assert_called_once()
 
 
+def test_rollback_kills_clone_before_delete():
+    """A failed clone is disposable, so rollback kills it before deletion."""
+    app = MagicMock()
+    upgrader = template_upgrade.TemplateUpgrader(app, Mock(), Mock())
+    upgrader.cloned_qube = Mock()
+    upgrader.cloned_qube.name = "fedora-42"
+
+    upgrader.rollback()
+
+    upgrader.cloned_qube.kill.assert_called_once_with()
+    app.domains.__delitem__.assert_called_once_with("fedora-42")
+
+
+def test_rollback_deletes_clone_if_already_halted():
+    """kill() raises QubesVMNotStartedError when the clone is already down;
+    deletion must still run."""
+    app = MagicMock()
+    upgrader = template_upgrade.TemplateUpgrader(app, Mock(), Mock())
+    upgrader.cloned_qube = Mock()
+    upgrader.cloned_qube.name = "fedora-42"
+    upgrader.cloned_qube.kill.side_effect = (
+        qubesadmin.exc.QubesVMNotStartedError("already halted")
+    )
+
+    upgrader.rollback()
+
+    app.domains.__delitem__.assert_called_once_with("fedora-42")
+
+
 def _reset_template_upgrade_logger():
     logger = logging.getLogger("vm-template-upgrade")
     logger.handlers.clear()
@@ -313,7 +420,9 @@ def test_setup_logging_is_idempotent(tmp_path, monkeypatch):
     """Calling setup_logging twice must not duplicate handlers."""
     monkeypatch.setattr(template_upgrade, "setup_logging", _REAL_SETUP_LOGGING)
     monkeypatch.setattr(
-        template_upgrade, "LOG_PATH", str(tmp_path / "qvm-template-upgrade.log")
+        template_upgrade,
+        "LOG_PATH",
+        str(tmp_path / "qvm-template-upgrade.log"),
     )
     _reset_template_upgrade_logger()
 

--- a/vmupdate/tests/test_template_upgrade.py
+++ b/vmupdate/tests/test_template_upgrade.py
@@ -123,7 +123,7 @@ def test_dry_run_does_not_mutate(capsys):
             "os-distribution": "ubuntu",
             "os-distribution-like": "debian",
             "os-version": "22",
-        }
+        },
     )
     before = dict(vm.features)
 
@@ -135,6 +135,44 @@ def test_dry_run_does_not_mutate(capsys):
     assert app.clone_calls == []
     assert vm.features == before
     assert "would clone ubuntu-22 -> ubuntu-23" in capsys.readouterr().out
+
+
+def test_finalize_failure_does_not_roll_back(monkeypatch, capsys):
+    # a metadata-write failure after a successful in-VM upgrade must keep
+    # the upgraded clone; only run_agent failures trigger rollback
+    app = CloneApp()
+    add_template(app)
+
+    def fake_update_qube(qube, agent_args, **kwargs):
+        return qube.name, ProcessResult(EXIT.OK)
+
+    def failing_finalize(self):
+        raise template_upgrade.qubesadmin.exc.QubesException(
+            "feature write failed"
+        )
+
+    monkeypatch.setattr(template_upgrade, "update_qube", fake_update_qube)
+    monkeypatch.setattr(
+        template_upgrade.TemplateUpgrader, "finalize", failing_finalize
+    )
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.OK
+    assert "fedora-42" in app.domains  # upgraded clone kept
+    assert "Set them manually" in capsys.readouterr().err
+
+
+def test_detect_distro_prefers_os_distribution_over_distro_like():
+    # priority is os-distribution first, then os-distribution-like -- never
+    # alphabetical: a Fedora template listing debian in distro-like must
+    # take the Fedora path
+    app = CloneApp()
+    vm = add_template(app, **{"os-distribution-like": "debian"})
+    upgrader = template_upgrade.TemplateUpgrader(app, None, Mock())
+    upgrader.source_vm = vm
+
+    assert upgrader._detect_distro() == ("fedora", "41")
 
 
 def test_unsupported_distro_message_lists_supported_families(capsys):
@@ -258,6 +296,39 @@ def test_run_agent_failure_rolls_back_clone(monkeypatch, capsys):
     assert retcode == EXIT.ERR
     assert "fedora-42" not in app.domains
     assert "version-upgrade agent failed" in capsys.readouterr().err
+
+
+def _add_debian_template(app, name="debian-12"):
+    return add_template(
+        app,
+        name,
+        **{
+            "os-distribution": "debian",
+            "os-version": "12",
+            "template-version": "12",
+        },
+    )
+
+
+def test_run_agent_success_debian_invokes_transport(monkeypatch):
+    """The distro-agnostic orchestrator drives Debian end-to-end."""
+    app = CloneApp()
+    _add_debian_template(app)
+    captured = {}
+
+    def fake_update_qube(qube, agent_args, **kwargs):
+        captured["qube"] = qube
+        captured["agent_args"] = agent_args
+        return qube.name, ProcessResult(EXIT.OK)
+
+    monkeypatch.setattr(template_upgrade, "update_qube", fake_update_qube)
+
+    retcode = template_upgrade.main(["--template", "debian-12"], app)
+
+    assert retcode == EXIT.OK
+    assert captured["qube"].name == "debian-13"
+    assert captured["agent_args"].version_upgrade == "13"
+    assert app.domains["debian-13"].features["template-name"] == "debian-13"
 
 
 @pytest.mark.parametrize(

--- a/vmupdate/tests/test_template_upgrade.py
+++ b/vmupdate/tests/test_template_upgrade.py
@@ -1,0 +1,347 @@
+#!/usr/bin/python3
+# coding=utf-8
+import logging
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+import qubesadmin.exc
+
+from vmupdate import template_upgrade
+from vmupdate.agent.source.common.exit_codes import EXIT
+from vmupdate.tests.conftest import TestApp as _TestApp
+from vmupdate.tests.conftest import TestVM as _TestVM
+
+# Captured at import time, before the quiet_logging autouse fixture can
+# replace it. Tests that need to exercise the real setup_logging restore
+# this reference explicitly.
+_REAL_SETUP_LOGGING = template_upgrade.setup_logging
+
+
+class CloneApp(_TestApp):
+    def __init__(self):
+        super().__init__()
+        self.clone_calls = []
+
+    def clone_vm(self, source_vm, new_name):
+        self.clone_calls.append((source_vm.name, new_name))
+        clone = _TestVM(new_name, self, klass=source_vm.klass)
+        clone.features.update(source_vm.features)
+        return clone
+
+
+def add_template(app, name="fedora-41", **features):
+    vm = _TestVM(name, app, klass="TemplateVM")
+    vm.features.update(
+        {
+            "os-distribution": "fedora",
+            "os-version": "41",
+            "template-name": name,
+            "template-epoch": "0",
+            "template-version": "41",
+            "template-release": "20250101",
+            "template-buildtime": "2025-01-01 00:00:00",
+        }
+    )
+    vm.features.update(features)
+    return vm
+
+
+def add_standalone(app, name="fedora-41-standalone", **features):
+    vm = _TestVM(name, app, klass="StandaloneVM")
+    vm.features.update(
+        {
+            "os-distribution": "fedora",
+            "os-version": "41",
+        }
+    )
+    vm.features.update(features)
+    return vm
+
+
+@pytest.fixture(autouse=True)
+def quiet_logging(monkeypatch):
+    monkeypatch.setattr(template_upgrade, "setup_logging", lambda *_: Mock())
+
+
+@pytest.mark.parametrize(
+    "scenario, expected",
+    [
+        ("missing-qube", "No such qube"),
+        ("non-template", "only TemplateVMs and StandaloneVMs"),
+        ("missing-os-version", "missing os-distribution / os-version"),
+        ("non-numeric-os-version", "Non-numeric distro version"),
+        ("unsupported-distro", "Unsupported distro"),
+    ],
+)
+def test_validation_errors(scenario, expected, capsys):
+    app = CloneApp()
+    template_name = "fedora-41"
+    if scenario == "non-template":
+        _TestVM(template_name, app, klass="AppVM", template=add_template(app))
+    elif scenario == "missing-os-version":
+        add_template(app)
+        del app.domains[template_name].features["os-version"]
+    elif scenario == "non-numeric-os-version":
+        add_template(app, **{"os-version": "rawhide"})
+    elif scenario == "unsupported-distro":
+        add_template(app, **{"os-distribution": "arch"})
+
+    retcode = template_upgrade.main(["--template", template_name], app)
+
+    assert retcode == EXIT.ERR_USAGE
+    assert expected in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "source, current, target, override, expected",
+    [
+        ("fedora-41", "41", "42", None, "fedora-42"),
+        ("debian-12", "12", "13", None, "debian-13"),
+        ("fedora-41-minimal", "41", "42", None, "fedora-42-minimal"),
+        ("custom", "41", "42", None, "custom-42"),
+        ("custom", "41", "42", "my-template", "my-template"),
+    ],
+)
+def test_clone_name_derivation(source, current, target, override, expected):
+    assert (
+        template_upgrade.derive_clone_name(source, current, target, override)
+        == expected
+    )
+
+
+def test_dry_run_does_not_mutate(capsys):
+    app = CloneApp()
+    vm = add_template(
+        app,
+        "ubuntu-22",
+        **{
+            "os-distribution": "ubuntu",
+            "os-distribution-like": "debian",
+            "os-version": "22",
+        }
+    )
+    before = dict(vm.features)
+
+    retcode = template_upgrade.main(
+        ["--template", "ubuntu-22", "--dry-run"], app
+    )
+
+    assert retcode == EXIT.OK
+    assert app.clone_calls == []
+    assert vm.features == before
+    assert "would clone ubuntu-22 -> ubuntu-23" in capsys.readouterr().out
+
+
+def test_success_applies_metadata(monkeypatch):
+    app = CloneApp()
+    add_template(app)
+    monkeypatch.setattr(
+        template_upgrade.TemplateUpgrader, "run_agent", lambda self: None
+    )
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.OK
+    clone = app.domains["fedora-42"]
+    assert clone.features["template-name"] == "fedora-42"
+    assert clone.features["template-installtime"] != app.domains[
+        "fedora-41"
+    ].features.get("template-installtime")
+    assert clone.features["template-epoch"] == "0"
+    assert clone.features["template-version"] == "41"
+    assert clone.features["template-release"] == "20250101"
+    assert clone.features["template-buildtime"] == "2025-01-01 00:00:00"
+    assert clone.features["os-distribution"] == "fedora"
+    assert clone.features["os-version"] == "41"
+
+
+def test_standalone_without_template_name_left_alone(monkeypatch):
+    """A standalone that never had template-name doesn't get one invented."""
+    app = CloneApp()
+    add_standalone(app)
+    monkeypatch.setattr(
+        template_upgrade.TemplateUpgrader, "run_agent", lambda self: None
+    )
+
+    retcode = template_upgrade.main(["--template", "fedora-41-standalone"], app)
+
+    assert retcode == EXIT.OK
+    clone = app.domains["fedora-42-standalone"]
+    assert clone.klass == "StandaloneVM"
+    assert "template-name" not in clone.features
+    assert "template-installtime" not in clone.features
+
+
+def test_standalone_with_template_name_refreshed(monkeypatch):
+    """Refresh stale standalone template-name for updater EOL checks."""
+    app = CloneApp()
+    add_standalone(app, **{"template-name": "fedora-41"})
+    monkeypatch.setattr(
+        template_upgrade.TemplateUpgrader, "run_agent", lambda self: None
+    )
+
+    retcode = template_upgrade.main(["--template", "fedora-41-standalone"], app)
+
+    assert retcode == EXIT.OK
+    clone = app.domains["fedora-42-standalone"]
+    # check_support() resolves this through EOL_DATES.
+    assert clone.features["template-name"] == "fedora-42"
+    # template-installtime is template-only; standalones don't get one.
+    assert "template-installtime" not in clone.features
+
+
+def test_default_stub_fails_and_cleans_clone(capsys):
+    app = CloneApp()
+    add_template(app)
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.ERR
+    assert "fedora-42" not in app.domains
+    assert "not implemented yet" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "keep_on_failure, expect_clone_removed",
+    [
+        (False, True),
+        (True, False),
+    ],
+)
+def test_failure_cleanup(monkeypatch, keep_on_failure, expect_clone_removed):
+    app = CloneApp()
+    add_template(app)
+
+    def fail_agent(self):
+        raise template_upgrade.UpgradeError("agent failed")
+
+    monkeypatch.setattr(
+        template_upgrade.TemplateUpgrader, "run_agent", fail_agent
+    )
+    args = ["--template", "fedora-41"]
+    if keep_on_failure:
+        args.append("--keep-new-on-failure")
+
+    retcode = template_upgrade.main(args, app)
+
+    assert retcode == EXIT.ERR
+    assert ("fedora-42" not in app.domains) is expect_clone_removed
+
+
+def test_rejects_existing_clone_name(capsys):
+    """If the target clone name already exists, validation fails before
+    anything is mutated."""
+    app = CloneApp()
+    add_template(app)
+    add_template(app, name="fedora-42", **{"os-version": "42"})
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.ERR_USAGE
+    assert "already exists" in capsys.readouterr().err
+    assert app.clone_calls == []
+
+
+def test_standalone_template_name_without_version_is_left_alone(monkeypatch):
+    """Standalone whose template-name doesn't carry the current version
+    (custom string, manual edit) is left untouched."""
+    app = CloneApp()
+    add_standalone(app, **{"template-name": "my-custom-base"})
+    monkeypatch.setattr(
+        template_upgrade.TemplateUpgrader, "run_agent", lambda self: None
+    )
+
+    retcode = template_upgrade.main(["--template", "fedora-41-standalone"], app)
+
+    assert retcode == EXIT.OK
+    clone = app.domains["fedora-42-standalone"]
+    assert clone.features["template-name"] == "my-custom-base"
+
+
+def test_main_clone_failure(monkeypatch, capsys):
+    """If the Admin-API clone call raises, main() reports it as a runtime
+    error (EXIT.ERR), not a usage error."""
+    app = CloneApp()
+    add_template(app)
+
+    def boom(*_a, **_kw):
+        raise qubesadmin.exc.QubesException("storage pool full")
+
+    monkeypatch.setattr(app, "clone_vm", boom)
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.ERR
+    assert "clone failed: storage pool full" in capsys.readouterr().err
+
+
+def test_rollback_noop_when_no_clone():
+    """rollback() before clone() ran is a safe no-op."""
+    upgrader = template_upgrade.TemplateUpgrader(CloneApp(), Mock(), Mock())
+    upgrader.rollback()  # must not raise
+
+
+def test_rollback_handles_delete_failure():
+    """If the Admin-API delete raises, rollback logs and swallows; the
+    caller has already decided the upgrade has failed, so re-raising would
+    just mask the original error.
+    """
+    # dict's __delitem__ is looked up on the type, not the instance, so we
+    # use a MagicMock for app.domains (which supports __delitem__ as a side
+    # effect) instead of trying to patch the test-helper Domains dict.
+    app = MagicMock()
+    app.domains.__delitem__.side_effect = qubesadmin.exc.QubesException(
+        "VM is running"
+    )
+    upgrader = template_upgrade.TemplateUpgrader(app, Mock(), Mock())
+    upgrader.cloned_qube = Mock(name="fedora-42")
+    upgrader.cloned_qube.name = "fedora-42"
+
+    upgrader.rollback()  # must not raise
+
+    upgrader.log.error.assert_called_once()
+
+
+def _reset_template_upgrade_logger():
+    logger = logging.getLogger("vm-template-upgrade")
+    logger.handlers.clear()
+    logger.propagate = True
+
+
+def test_setup_logging_is_idempotent(tmp_path, monkeypatch):
+    """Calling setup_logging twice must not duplicate handlers."""
+    monkeypatch.setattr(template_upgrade, "setup_logging", _REAL_SETUP_LOGGING)
+    monkeypatch.setattr(
+        template_upgrade, "LOG_PATH", str(tmp_path / "qvm-template-upgrade.log")
+    )
+    _reset_template_upgrade_logger()
+
+    log1 = template_upgrade.setup_logging("INFO")
+    handler_count = len(log1.handlers)
+    log2 = template_upgrade.setup_logging("INFO")
+
+    assert log1 is log2
+    assert len(log2.handlers) == handler_count
+    assert log2.propagate is False
+
+
+def test_setup_logging_tolerates_missing_log_dir(tmp_path, monkeypatch):
+    """A missing log directory degrades to stderr-only, not a crash."""
+    monkeypatch.setattr(template_upgrade, "setup_logging", _REAL_SETUP_LOGGING)
+    monkeypatch.setattr(
+        template_upgrade,
+        "LOG_PATH",
+        str(tmp_path / "nope" / "qvm-template-upgrade.log"),
+    )
+    _reset_template_upgrade_logger()
+
+    log = template_upgrade.setup_logging("INFO")
+
+    # The file handler should have been skipped; stderr stays.
+    assert not any(isinstance(h, logging.FileHandler) for h in log.handlers)
+    assert any(
+        isinstance(h, logging.StreamHandler)
+        and not isinstance(h, logging.FileHandler)
+        for h in log.handlers
+    )

--- a/vmupdate/tests/test_template_upgrade.py
+++ b/vmupdate/tests/test_template_upgrade.py
@@ -1,0 +1,1116 @@
+#!/usr/bin/python3
+# coding=utf-8
+import io
+import logging
+import re
+import time
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from tqdm import tqdm
+
+import qubesadmin.exc
+
+from vmupdate import template_upgrade
+from vmupdate.agent.source.common.exit_codes import EXIT
+from vmupdate.agent.source.common.process_result import ProcessResult
+from vmupdate.agent.source.status import (
+    FinalStatus,
+    FormatedLine,
+    StatusInfo,
+)
+from vmupdate.tests.conftest import TestApp as _TestApp
+from vmupdate.tests.conftest import TestVM as _TestVM
+
+# Captured at import time, before the quiet_logging autouse fixture can
+# replace it. Tests that need to exercise the real setup_logging restore
+# this reference explicitly.
+_REAL_SETUP_LOGGING = template_upgrade.setup_logging
+
+
+class CloneApp(_TestApp):
+    def __init__(self) -> None:
+        super().__init__()
+        self.clone_calls: list[tuple[str, str]] = []
+
+    def clone_vm(self, source_vm, new_name) -> _TestVM:
+        self.clone_calls.append((source_vm.name, new_name))
+        clone = _TestVM(new_name, self, klass=source_vm.klass)
+        clone.features.update(source_vm.features)
+        # A freshly cloned qube hasn't been started, so rollback() shouldn't
+        # try to force it down. (TestVM defaults running=True.)
+        clone.running = False
+        return clone
+
+
+def add_template(app, name="fedora-41", **features) -> _TestVM:
+    vm = _TestVM(name, app, klass="TemplateVM")
+    vm.features.update(
+        {
+            "os-distribution": "fedora",
+            "os-version": "41",
+            "template-name": name,
+            "template-epoch": "0",
+            "template-version": "41",
+            "template-release": "20250101",
+            "template-reponame": "@commandline",
+            "template-buildtime": "2025-01-01 00:00:00",
+            "template-license": "GPLv3+",
+            "template-url": "http://www.qubes-os.org",
+            "template-summary": "Qubes OS template for fedora-41",
+            "template-description": "Qubes OS template for fedora-41.",
+        }
+    )
+    vm.features.update(features)
+    return vm
+
+
+def add_standalone(app, name="fedora-41-standalone", **features) -> _TestVM:
+    vm = _TestVM(name, app, klass="StandaloneVM")
+    vm.features.update(
+        {
+            "os-distribution": "fedora",
+            "os-version": "41",
+        }
+    )
+    vm.features.update(features)
+    return vm
+
+
+@pytest.fixture(autouse=True)
+def quiet_logging(monkeypatch) -> None:
+    monkeypatch.setattr(template_upgrade, "setup_logging", lambda *_: Mock())
+
+
+@pytest.mark.parametrize(
+    "scenario, expected",
+    [
+        ("missing-qube", "No such qube"),
+        ("non-template", "only TemplateVMs and StandaloneVMs"),
+        ("missing-os-version", "missing os-distribution / os-version"),
+        ("non-numeric-os-version", "Non-numeric distro version"),
+        ("unsupported-distro", "Unsupported distro"),
+        ("derivative-distro", "Kicksecure derivative"),
+    ],
+)
+def test_validation_errors(scenario, expected, capsys) -> None:
+    app = CloneApp()
+    template_name = "fedora-41"
+    if scenario == "non-template":
+        _TestVM(template_name, app, klass="AppVM", template=add_template(app))
+    elif scenario == "missing-os-version":
+        add_template(app)
+        del app.domains[template_name].features["os-version"]
+    elif scenario == "non-numeric-os-version":
+        add_template(app, **{"os-version": "rawhide"})
+    elif scenario == "unsupported-distro":
+        add_template(app, **{"os-distribution": "arch"})
+    elif scenario == "derivative-distro":
+        add_template(
+            app,
+            **{
+                "os-distribution": "Kicksecure",
+                "os-distribution-like": "debian",
+                "os-version": "17",
+            },
+        )
+
+    retcode = template_upgrade.main(["--template", template_name], app)
+
+    assert retcode == EXIT.ERR_USAGE
+    assert expected in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "source, current, target, override, expected",
+    [
+        ("fedora-41", "41", "42", None, "fedora-42"),
+        ("debian-12", "12", "13", None, "debian-13"),
+        ("fedora-41-minimal", "41", "42", None, "fedora-42-minimal"),
+        ("custom", "41", "42", None, "custom-42"),
+        ("custom", "41", "42", "my-template", "my-template"),
+        # "12" must not match inside the digit run "121".
+        ("debian-121", "12", "13", None, "debian-121-13"),
+        # Only the last stand-alone occurrence is replaced.
+        ("fedora-41-extras-41", "41", "42", None, "fedora-41-extras-42"),
+    ],
+)
+def test_clone_name_derivation(
+    source, current, target, override, expected
+) -> None:
+    assert (
+        template_upgrade.derive_clone_name(source, current, target, override)
+        == expected
+    )
+
+
+def test_dry_run_does_not_mutate(capsys) -> None:
+    app = CloneApp()
+    vm = add_template(
+        app,
+        "debian-12",
+        **{
+            "os-distribution": "debian",
+            "os-version": "12",
+        },
+    )
+    before = dict(vm.features)
+
+    retcode = template_upgrade.main(
+        ["--template", "debian-12", "--dry-run"], app
+    )
+
+    assert retcode == EXIT.OK
+    assert app.clone_calls == []
+    assert vm.features == before
+    assert "would clone debian-12 -> debian-13" in capsys.readouterr().out
+
+
+def test_rejects_derivative_distro(capsys) -> None:
+    """A qube matched only via os-distribution-like has its own version
+    scheme, so target = version + 1 would be meaningless; refuse it."""
+    app = CloneApp()
+    add_template(
+        app,
+        "kicksecure-17",
+        **{
+            "os-distribution": "Kicksecure",
+            "os-distribution-like": "debian",
+            "os-version": "17",
+        },
+    )
+
+    retcode = template_upgrade.main(["--template", "kicksecure-17"], app)
+
+    assert retcode == EXIT.ERR_USAGE
+    err = capsys.readouterr().err
+    assert "Kicksecure derivative" in err
+    assert "does not match debian's releases" in err
+    assert app.clone_calls == []
+
+
+def test_finalize_failure_does_not_roll_back(monkeypatch, capsys) -> None:
+    # a metadata-write failure after a successful in-VM upgrade must keep
+    # the upgraded clone; only run_agent failures trigger rollback
+    app = CloneApp()
+    add_template(app)
+
+    def fake_update_qube(
+        qube, agent_args, **kwargs
+    ) -> tuple[str, ProcessResult]:
+        return qube.name, ProcessResult(EXIT.OK)
+
+    def failing_finalize(self) -> None:
+        raise template_upgrade.qubesadmin.exc.QubesException(
+            "feature write failed"
+        )
+
+    monkeypatch.setattr(template_upgrade, "update_qube", fake_update_qube)
+    monkeypatch.setattr(
+        template_upgrade.TemplateUpgrader, "finalize", failing_finalize
+    )
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.OK
+    assert "fedora-42" in app.domains  # upgraded clone kept
+    assert "Set them manually" in capsys.readouterr().err
+
+
+def test_detect_distro_prefers_os_distribution_over_distro_like() -> None:
+    # priority is os-distribution first, then os-distribution-like -- never
+    # alphabetical: a Fedora template listing debian in distro-like must
+    # take the Fedora path
+    app = CloneApp()
+    vm = add_template(app, **{"os-distribution-like": "debian"})
+    upgrader = template_upgrade.TemplateUpgrader(app, Mock(), Mock())
+    upgrader.source_vm = vm
+
+    assert upgrader._detect_distro() == ("fedora", "41")
+
+
+def test_unsupported_distro_message_lists_supported_families(capsys) -> None:
+    app = CloneApp()
+    add_template(app, **{"os-distribution": "arch"})
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.ERR_USAGE
+    assert (
+        "supported distro families are: Debian, Fedora"
+        in capsys.readouterr().err
+    )
+
+
+def test_success_applies_metadata(monkeypatch, capsys) -> None:
+    app = CloneApp()
+    add_template(
+        app,
+        **{
+            "template-summary": "Qubes OS template for fedora-41",
+            "template-description": "Qubes OS template for fedora-41.",
+        },
+    )
+    monkeypatch.setattr(
+        template_upgrade.TemplateUpgrader, "run_agent", lambda self: None
+    )
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.OK
+    assert (
+        "Upgrade complete. New template: fedora-42" in capsys.readouterr().out
+    )
+    clone = app.domains["fedora-42"]
+    assert clone.features["template-name"] == "fedora-42"
+    # qvm-template parses this one with strptime(DATE_FMT).
+    datetime.strptime(
+        clone.features["template-installtime"], template_upgrade.DATE_FMT
+    )
+    # EVR feeds qvm-template's repo comparisons, so it stays as inherited.
+    assert clone.features["template-epoch"] == "0"
+    assert clone.features["template-version"] == "41"
+    assert clone.features["template-release"] == "20250101"
+    # Provenance, though, is now this tool and this moment.
+    assert clone.features["template-reponame"] == "@qvm-template-upgrade"
+    assert clone.features["template-buildtime"] != "2025-01-01 00:00:00"
+    assert (
+        clone.features["template-buildtime"]
+        == clone.features["template-installtime"]
+    )
+    assert clone.features["os-distribution"] == "fedora"
+    # finalize() backstops os-version even if qubes.PostInstall's feature
+    # refresh failed; the in-VM agent verified the new release.
+    assert clone.features["os-version"] == "42"
+    # Inherited summary/description mention the source name; qvm-template
+    # list must describe the clone, not the qube it was upgraded from.
+    assert (
+        clone.features["template-summary"] == "Qubes OS template for fedora-42"
+    )
+    assert (
+        clone.features["template-description"]
+        == "Qubes OS template for fedora-42."
+    )
+
+
+def test_upgraded_template_keeps_every_feature_qvm_template_reads(
+    monkeypatch,
+) -> None:
+    """qvm-template's query_local() subscripts these directly, so an upgraded
+    template missing any of them makes `qvm-template list` raise KeyError
+    instead of just describing the qube oddly."""
+    app = CloneApp()
+    add_template(app)
+    monkeypatch.setattr(
+        template_upgrade.TemplateUpgrader, "run_agent", lambda self: None
+    )
+
+    template_upgrade.main(["--template", "fedora-41"], app)
+
+    features = app.domains["fedora-42"].features
+    for required in (
+        "template-name",
+        "template-epoch",
+        "template-version",
+        "template-release",
+        "template-reponame",
+        "template-buildtime",
+        "template-license",
+        "template-url",
+        "template-summary",
+        "template-description",
+    ):
+        assert required in features, required
+    # qvm-template parses this one with strptime(DATE_FMT).
+    datetime.strptime(
+        features["template-buildtime"], template_upgrade.DATE_FMT
+    )
+
+
+def test_custom_template_description_left_untouched(monkeypatch) -> None:
+    """A summary/description that doesn't mention the source name is user
+    text and must survive the upgrade unchanged."""
+    app = CloneApp()
+    add_template(app, **{"template-description": "My hardened browser base"})
+    monkeypatch.setattr(
+        template_upgrade.TemplateUpgrader, "run_agent", lambda self: None
+    )
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.OK
+    clone = app.domains["fedora-42"]
+    assert clone.features["template-description"] == "My hardened browser base"
+
+
+def test_standalone_without_template_name_left_alone(
+    monkeypatch, capsys
+) -> None:
+    """A standalone that never had template-name doesn't get one invented."""
+    app = CloneApp()
+    add_standalone(app)
+    monkeypatch.setattr(
+        template_upgrade.TemplateUpgrader, "run_agent", lambda self: None
+    )
+
+    retcode = template_upgrade.main(
+        ["--template", "fedora-41-standalone"], app
+    )
+
+    assert retcode == EXIT.OK
+    assert (
+        "Upgrade complete. New standalone: fedora-42-standalone"
+        in capsys.readouterr().out
+    )
+    clone = app.domains["fedora-42-standalone"]
+    assert clone.klass == "StandaloneVM"
+    assert "template-name" not in clone.features
+    assert "template-installtime" not in clone.features
+    # The os-version backstop applies to standalones too.
+    assert clone.features["os-version"] == "42"
+
+
+def test_standalone_template_name_left_untouched(monkeypatch) -> None:
+    """A standalone's template-* features are never rewritten; the clone
+    keeps whatever it inherited from the source."""
+    app = CloneApp()
+    add_standalone(app, **{"template-name": "fedora-41"})
+    monkeypatch.setattr(
+        template_upgrade.TemplateUpgrader, "run_agent", lambda self: None
+    )
+
+    retcode = template_upgrade.main(
+        ["--template", "fedora-41-standalone"], app
+    )
+
+    assert retcode == EXIT.OK
+    clone = app.domains["fedora-42-standalone"]
+    # The clone inherits the source value; the tool does not touch it.
+    assert clone.features["template-name"] == "fedora-41"
+    assert "template-installtime" not in clone.features
+
+
+def test_run_agent_success_invokes_transport(monkeypatch) -> None:
+    """A successful agent run upgrades the clone (not the source) in
+    single-qube VM mode and tells the agent the exact target release."""
+    app = CloneApp()
+    add_template(app)
+    captured: dict[str, Any] = {}
+
+    def fake_update_qube(
+        qube, agent_args, **kwargs
+    ) -> tuple[str, ProcessResult]:
+        captured["qube"] = qube
+        captured["agent_args"] = agent_args
+        captured["kwargs"] = kwargs
+        return qube.name, ProcessResult(EXIT.OK)
+
+    monkeypatch.setattr(template_upgrade, "update_qube", fake_update_qube)
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.OK
+    assert captured["qube"].name == "fedora-42"
+    assert captured["kwargs"]["dom0"] is False
+    assert captured["kwargs"]["show_progress"] is True
+    assert captured["agent_args"].version_upgrade == "42"
+    assert captured["agent_args"].display_name is None
+    # success path still applies post-upgrade metadata
+    assert app.domains["fedora-42"].features["template-name"] == "fedora-42"
+
+
+def test_run_agent_failure_rolls_back_clone(monkeypatch, capsys) -> None:
+    """A non-zero agent exit becomes an UpgradeError and the clone is
+    removed (the wired replacement for the old NotImplementedError stub)."""
+    app = CloneApp()
+    add_template(app)
+
+    def fake_update_qube(
+        qube, agent_args, **kwargs
+    ) -> tuple[str, ProcessResult]:
+        return qube.name, ProcessResult(EXIT.ERR_VM_UPDATE)
+
+    monkeypatch.setattr(template_upgrade, "update_qube", fake_update_qube)
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.ERR
+    assert "fedora-42" not in app.domains
+    assert "version-upgrade agent failed" in capsys.readouterr().err
+
+
+def _add_debian_template(app, name="debian-12") -> _TestVM:
+    return add_template(
+        app,
+        name,
+        **{
+            "os-distribution": "debian",
+            "os-version": "12",
+            "template-version": "12",
+        },
+    )
+
+
+def test_run_agent_success_debian_invokes_transport(monkeypatch) -> None:
+    """Verify Debian template upgrade works end-to-end."""
+    app = CloneApp()
+    _add_debian_template(app)
+    captured: dict[str, Any] = {}
+
+    def fake_update_qube(
+        qube, agent_args, **kwargs
+    ) -> tuple[str, ProcessResult]:
+        captured["qube"] = qube
+        captured["agent_args"] = agent_args
+        return qube.name, ProcessResult(EXIT.OK)
+
+    monkeypatch.setattr(template_upgrade, "update_qube", fake_update_qube)
+
+    retcode = template_upgrade.main(["--template", "debian-12"], app)
+
+    assert retcode == EXIT.OK
+    assert captured["qube"].name == "debian-13"
+    assert captured["agent_args"].version_upgrade == "13"
+    assert app.domains["debian-13"].features["template-name"] == "debian-13"
+
+
+@pytest.mark.parametrize(
+    "keep_on_failure, expect_clone_removed",
+    [
+        (False, True),
+        (True, False),
+    ],
+)
+def test_failure_cleanup(
+    monkeypatch, keep_on_failure, expect_clone_removed
+) -> None:
+    app = CloneApp()
+    add_template(app)
+
+    def fail_agent(self) -> None:
+        raise template_upgrade.UpgradeError("agent failed")
+
+    monkeypatch.setattr(
+        template_upgrade.TemplateUpgrader, "run_agent", fail_agent
+    )
+    args = ["--template", "fedora-41"]
+    if keep_on_failure:
+        args.append("--keep-new-on-failure")
+
+    retcode = template_upgrade.main(args, app)
+
+    assert retcode == EXIT.ERR
+    assert ("fedora-42" not in app.domains) is expect_clone_removed
+
+
+def test_rejects_existing_clone_name(capsys) -> None:
+    """If the target clone name already exists, validation fails before
+    anything is mutated."""
+    app = CloneApp()
+    add_template(app)
+    add_template(app, name="fedora-42", **{"os-version": "42"})
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.ERR_USAGE
+    assert "already exists" in capsys.readouterr().err
+    assert app.clone_calls == []
+
+
+def test_main_clone_failure(monkeypatch, capsys) -> None:
+    """If the Admin-API clone call raises, main() reports it as a runtime
+    error (EXIT.ERR), not a usage error."""
+    app = CloneApp()
+    add_template(app)
+
+    def boom(*_a, **_kw) -> None:
+        raise qubesadmin.exc.QubesException("storage pool full")
+
+    monkeypatch.setattr(app, "clone_vm", boom)
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.ERR
+    assert "clone failed: storage pool full" in capsys.readouterr().err
+
+
+def test_agent_output_forwards_lines_and_drops_status() -> None:
+    """FormatedLine output reaches the log; StatusInfo ticks are dropped."""
+    log = Mock()
+    sink = template_upgrade._AgentOutput(log)
+    qube = Mock()
+    qube.name = "fedora-42"
+
+    sink.put(FormatedLine("fedora-42", "out", "Downloading packages"))
+    sink.put("fedora-42:err: a plain string line")
+    sink.put(StatusInfo.updating(qube, 42.0))
+    sink.put(StatusInfo.done(qube, FinalStatus.SUCCESS))
+
+    # Only the two human-readable lines are logged.
+    assert log.info.call_count == 2
+
+
+def test_rollback_noop_when_no_clone() -> None:
+    """rollback() before clone() ran is a safe no-op."""
+    upgrader = template_upgrade.TemplateUpgrader(CloneApp(), Mock(), Mock())
+    upgrader.rollback()  # must not raise
+
+
+def test_rollback_handles_delete_failure() -> None:
+    """Rollback logs and ignores VM deletion errors."""
+    # Use MagicMock to support __delitem__ side effect.
+    app = MagicMock()
+    app.domains.__delitem__.side_effect = qubesadmin.exc.QubesException(
+        "VM is running"
+    )
+    log = Mock()
+    upgrader = template_upgrade.TemplateUpgrader(app, Mock(), log)
+    upgrader.cloned_qube = Mock(name="fedora-42")
+    upgrader.cloned_qube.name = "fedora-42"
+    upgrader.cloned_qube.get_power_state.return_value = "Halted"
+
+    upgrader.rollback()  # must not raise
+
+    log.error.assert_called_once()
+
+
+def test_rollback_kills_clone_before_delete() -> None:
+    """A failed clone is disposable, so rollback kills it before deletion."""
+    app = MagicMock()
+    upgrader = template_upgrade.TemplateUpgrader(app, Mock(), Mock())
+    upgrader.cloned_qube = Mock()
+    upgrader.cloned_qube.name = "fedora-42"
+    upgrader.cloned_qube.get_power_state.return_value = "Halted"
+
+    upgrader.rollback()
+
+    upgrader.cloned_qube.kill.assert_called_once_with()
+    app.domains.__delitem__.assert_called_once_with("fedora-42")
+
+
+def test_rollback_waits_for_halt_before_delete(monkeypatch) -> None:
+    """kill() returns before teardown completes; deleting too early fails
+    with "domain is not halted", so rollback polls until the clone halts."""
+    app = MagicMock()
+    upgrader = template_upgrade.TemplateUpgrader(app, Mock(), Mock())
+    upgrader.cloned_qube = Mock()
+    upgrader.cloned_qube.name = "fedora-42"
+    upgrader.cloned_qube.get_power_state.side_effect = [
+        "Running",
+        "Running",
+        "Halted",
+    ]
+    monkeypatch.setattr(template_upgrade.time, "sleep", lambda _s: None)
+
+    upgrader.rollback()
+
+    assert upgrader.cloned_qube.get_power_state.call_count == 3
+    app.domains.__delitem__.assert_called_once_with("fedora-42")
+
+
+def test_rollback_deletes_clone_if_already_halted() -> None:
+    """kill() raises QubesVMNotStartedError when the clone is already down;
+    deletion must still run."""
+    app = MagicMock()
+    upgrader = template_upgrade.TemplateUpgrader(app, Mock(), Mock())
+    upgrader.cloned_qube = Mock()
+    upgrader.cloned_qube.name = "fedora-42"
+    upgrader.cloned_qube.get_power_state.return_value = "Halted"
+    upgrader.cloned_qube.kill.side_effect = (
+        qubesadmin.exc.QubesVMNotStartedError("already halted")
+    )
+
+    upgrader.rollback()
+
+    app.domains.__delitem__.assert_called_once_with("fedora-42")
+
+
+def _reset_template_upgrade_logger() -> None:
+    for name in ("vm-template-upgrade", template_upgrade.AGENT_LOGGER):
+        logger = logging.getLogger(name)
+        logger.handlers.clear()
+        logger.propagate = True
+
+
+def test_setup_logging_is_idempotent(tmp_path, monkeypatch) -> None:
+    """Calling setup_logging twice must not duplicate handlers."""
+    monkeypatch.setattr(template_upgrade, "setup_logging", _REAL_SETUP_LOGGING)
+    monkeypatch.setattr(
+        template_upgrade,
+        "LOG_PATH",
+        str(tmp_path / "qvm-template-upgrade.log"),
+    )
+    _reset_template_upgrade_logger()
+
+    log1 = template_upgrade.setup_logging("INFO")
+    handler_count = len(log1.handlers)
+    log2 = template_upgrade.setup_logging("INFO")
+
+    assert log1 is log2
+    assert len(log2.handlers) == handler_count
+    assert log2.propagate is False
+
+
+def test_setup_logging_tolerates_missing_log_dir(
+    tmp_path, monkeypatch
+) -> None:
+    """A missing log directory degrades to stderr-only, not a crash."""
+    monkeypatch.setattr(template_upgrade, "setup_logging", _REAL_SETUP_LOGGING)
+    monkeypatch.setattr(
+        template_upgrade,
+        "LOG_PATH",
+        str(tmp_path / "nope" / "qvm-template-upgrade.log"),
+    )
+    _reset_template_upgrade_logger()
+
+    log = template_upgrade.setup_logging("INFO")
+
+    # The file handler should have been skipped; stderr stays.
+    assert not any(isinstance(h, logging.FileHandler) for h in log.handlers)
+    assert any(
+        isinstance(h, logging.StreamHandler)
+        and not isinstance(h, logging.FileHandler)
+        for h in log.handlers
+    )
+
+
+def test_setup_logging_agent_logger_is_file_only(
+    tmp_path, monkeypatch
+) -> None:
+    """Agent output logger should only write to file, not stderr."""
+    monkeypatch.setattr(template_upgrade, "setup_logging", _REAL_SETUP_LOGGING)
+    monkeypatch.setattr(
+        template_upgrade,
+        "LOG_PATH",
+        str(tmp_path / "qvm-template-upgrade.log"),
+    )
+    _reset_template_upgrade_logger()
+
+    template_upgrade.setup_logging("DEBUG")
+
+    agent_log = logging.getLogger(template_upgrade.AGENT_LOGGER)
+    assert agent_log.propagate is False
+    assert agent_log.handlers  # the shared file handler
+    assert all(isinstance(h, logging.FileHandler) for h in agent_log.handlers)
+
+
+def test_agent_output_logs_progress_ticks_at_debug() -> None:
+    """Progress StatusInfo ticks must land in the log at DEBUG so a run's
+    progress stream (monotonicity, where it stalled) can still be audited
+    afterwards, even without a progress bar."""
+    log = MagicMock()
+    sink = template_upgrade._AgentOutput(log)
+    qube = Mock()
+    qube.name = "fedora-42-xfce"
+
+    sink.put(StatusInfo.updating(qube, 42.5))
+    sink.put(FormatedLine("fedora-42-xfce", "out", "hello"))
+
+    log.debug.assert_called_once_with(
+        "%s progress: %s", "fedora-42-xfce", 42.5
+    )
+    log.info.assert_called_once()
+
+
+# _AgentOutput -- live progress bar
+
+
+def _bar_sink() -> tuple[MagicMock, MagicMock, template_upgrade._AgentOutput]:
+    """An _AgentOutput with mock log and mock bar, bar at 0%."""
+    log = MagicMock()
+    bar = MagicMock()
+    bar.n = 0.0
+    return log, bar, template_upgrade._AgentOutput(log, progress_bar=bar)
+
+
+def test_agent_output_advances_progress_bar() -> None:
+    _log, bar, sink = _bar_sink()
+    qube = Mock()
+    qube.name = "fedora-42-xfce"
+
+    sink.put(StatusInfo.updating(qube, 25.0))
+
+    bar.update.assert_called_once_with(25.0)
+
+
+def test_agent_output_bar_never_regresses() -> None:
+    """The transport can replay a lower percent (phase handoffs round down);
+    the bar must only ever move forward."""
+    _log, bar, sink = _bar_sink()
+    bar.n = 50.0
+    qube = Mock()
+    qube.name = "fedora-42-xfce"
+
+    sink.put(StatusInfo.updating(qube, 40.0))
+
+    bar.update.assert_not_called()
+
+
+def test_agent_output_bar_ignores_non_numeric_status() -> None:
+    """done/pending StatusInfo carries a FinalStatus or None, not a percent;
+    it must not be fed into the bar arithmetic."""
+    _log, bar, sink = _bar_sink()
+    qube = Mock()
+    qube.name = "fedora-42-xfce"
+
+    sink.put(StatusInfo.pending(qube))
+    sink.put(StatusInfo.done(qube, FinalStatus.SUCCESS))
+
+    bar.update.assert_not_called()
+
+
+def test_agent_output_lines_print_above_the_bar() -> None:
+    """Streamed lines go through the bar's write so tqdm reprints the bar
+    below each line instead of letting the line overwrite it."""
+    log, bar, sink = _bar_sink()
+
+    sink.put(FormatedLine("fedora-42-xfce", "out", "hello"))
+
+    log.info.assert_called_once()
+    bar.write.assert_called_once_with("fedora-42-xfce:out: hello")
+    bar.update.assert_not_called()
+
+
+def test_agent_output_streams_lines_without_a_bar(capsys) -> None:
+    """With no bar, agent lines stream to stdout (matching the
+    qubes-vm-update convention) and still land in the log."""
+    log = MagicMock()
+    sink = template_upgrade._AgentOutput(log)
+
+    sink.put(FormatedLine("fedora-42-xfce", "out", "Installing: bash"))
+
+    assert "Installing: bash" in capsys.readouterr().out
+    log.info.assert_called_once()
+
+
+def test_lines_stream_to_stdout_while_ticks_drive_the_bar(capsys) -> None:
+    """Verify stdout line streaming alongside progress bar updates."""
+
+    class FakeTty(io.StringIO):
+        def isatty(self) -> bool:  # tqdm asks the output stream
+            return True
+
+    out = FakeTty()
+    bar = tqdm(
+        total=100.0,
+        desc="fedora-42-xfce (fedora 41 -> 42)",
+        file=out,
+        bar_format="{desc} {percentage:5.1f}% |{bar}| [{elapsed}]",
+        mininterval=0,  # count every redraw; no wall-clock coalescing
+    )
+    sink = template_upgrade._AgentOutput(MagicMock(), progress_bar=bar)
+    qube = Mock()
+    qube.name = "fedora-42-xfce"
+
+    ticks = 100
+    lines_per_tick = 50  # 5000 package lines total
+    for i in range(ticks):
+        sink.put(StatusInfo.updating(qube, float(i + 1)))
+        for j in range(lines_per_tick):
+            sink.put(
+                FormatedLine(
+                    "fedora-42-xfce", "out", f"Installing pkg-{i}-{j}"
+                )
+            )
+    sink.close()
+
+    rendered = out.getvalue()
+    streamed = capsys.readouterr().out
+    assert rendered.count("\r") <= ticks + 5
+    assert "Installing" not in rendered
+    assert streamed.count("Installing") == ticks * lines_per_tick
+
+
+# _AgentOutput -- heartbeat that keeps an idle bar alive
+
+
+@pytest.mark.parametrize(
+    "quiet, expected",
+    [
+        (0.0, ""),
+        # Comfortably below QUIET_AFTER: a tighter margin would turn
+        # scheduler jitter into a spurious failure.
+        (25.0, ""),
+        # The recorded fedora 41 -> 42 run's two dead zones: 59s on 0.0% and
+        # 3m41s on 99.9%.
+        (59.0, "waiting 59s"),
+        (221.0, "waiting 3m41s"),
+        (3600.0, "waiting 60m00s"),
+    ],
+)
+def test_quiet_note_reports_a_stalled_percentage(quiet, expected) -> None:
+    _log, _bar, sink = _bar_sink()
+    sink._last_advance = time.monotonic() - quiet
+
+    assert sink._quiet_note() == expected
+
+
+def test_heartbeat_repaints_a_bar_the_agent_has_stopped_feeding(
+    monkeypatch,
+) -> None:
+    """The elapsed clock must keep moving while the agent is silent, or a
+    long transaction is indistinguishable from a hang."""
+    monkeypatch.setattr(
+        template_upgrade._AgentOutput, "HEARTBEAT_INTERVAL", 0.01
+    )
+    out = io.StringIO()
+    bar = tqdm(
+        total=100.0,
+        desc="fedora-42-xfce",
+        file=out,
+        bar_format="{desc} {percentage:5.1f}% |{bar}| [{elapsed}]{postfix}",
+        mininterval=0,
+    )
+    sink = template_upgrade._AgentOutput(MagicMock(), progress_bar=bar)
+
+    sink.start()
+    try:
+        deadline = time.monotonic() + 5.0
+        # No put() at all: every redraw here comes from the heartbeat.
+        while out.getvalue().count("\r") < 3 and time.monotonic() < deadline:
+            time.sleep(0.01)
+    finally:
+        sink.close()
+
+    assert out.getvalue().count("\r") >= 3
+
+
+def test_waiting_note_renders_with_a_single_separator() -> None:
+    """tqdm prepends ", " to a non-empty postfix itself, so _quiet_note must
+    not add its own spacing on top of it."""
+    out = io.StringIO()
+    bar = tqdm(
+        total=100.0,
+        desc="fedora-42-xfce",
+        file=out,
+        bar_format="{desc} {percentage:5.1f}% |{bar:10}| [{elapsed}]{postfix}",
+        mininterval=0,
+        ncols=80,
+    )
+    sink = template_upgrade._AgentOutput(MagicMock(), progress_bar=bar)
+    sink._last_advance = time.monotonic() - 221
+
+    bar.set_postfix_str(sink._quiet_note(), refresh=False)
+    bar.refresh()
+    frames = [f for f in out.getvalue().split("\r") if f.strip()]
+    sink.close()
+
+    # The elapsed clock is real time and not the point here; what must hold
+    # is that exactly one ", " separates it from the note.
+    assert re.search(r"\[\d\d:\d\d\], waiting 3m41s$", frames[-1]), frames[-1]
+
+
+def test_heartbeat_survives_nothing_but_stops_on_a_broken_terminal(
+    monkeypatch,
+) -> None:
+    """Heartbeat thread terminates cleanly on terminal write errors."""
+    monkeypatch.setattr(
+        template_upgrade._AgentOutput, "HEARTBEAT_INTERVAL", 0.01
+    )
+    log = MagicMock()
+    bar = MagicMock()
+    bar.n = 0.0
+    bar.refresh.side_effect = OSError("terminal went away")
+    sink = template_upgrade._AgentOutput(log, progress_bar=bar)
+
+    sink.start()
+    thread = sink._heartbeat
+    assert thread is not None
+    thread.join(timeout=5.0)
+
+    assert not thread.is_alive(), "heartbeat should stop, not spin on errors"
+    log.debug.assert_called_once()
+    assert "heartbeat" in log.debug.call_args.args[0]
+    sink.close()
+
+
+def test_final_line_carries_no_waiting_residue() -> None:
+    """Whatever the bar said while stalled, the line left on screen after
+    close() must not still claim to be waiting."""
+    out = io.StringIO()
+    bar = tqdm(
+        total=100.0,
+        desc="fedora-42-xfce",
+        file=out,
+        bar_format="{desc} {percentage:5.1f}% |{bar:10}| [{elapsed}]{postfix}",
+        mininterval=0,
+        ncols=80,
+    )
+    sink = template_upgrade._AgentOutput(MagicMock(), progress_bar=bar)
+    sink._last_advance = time.monotonic() - 300
+    bar.set_postfix_str(sink._quiet_note(), refresh=False)
+    bar.refresh()
+
+    sink.close()
+
+    assert "waiting" not in out.getvalue().split("\r")[-1]
+
+
+def test_heartbeat_is_not_started_without_a_bar() -> None:
+    """Non-TTY runs have no bar to repaint."""
+    sink = template_upgrade._AgentOutput(MagicMock())
+
+    sink.start()
+
+    assert sink._heartbeat is None
+    sink.close()
+
+
+def test_close_stops_the_heartbeat_thread(monkeypatch) -> None:
+    monkeypatch.setattr(
+        template_upgrade._AgentOutput, "HEARTBEAT_INTERVAL", 0.01
+    )
+    _log, bar, sink = _bar_sink()
+
+    sink.start()
+    thread = sink._heartbeat
+    assert thread is not None and thread.is_alive()
+    sink.close()
+
+    assert not thread.is_alive()
+    assert sink._heartbeat is None
+
+
+def test_progress_clears_the_waiting_note() -> None:
+    """Once the percentage moves again the bar must stop claiming to wait."""
+    _log, bar, sink = _bar_sink()
+    qube = Mock()
+    qube.name = "fedora-42-xfce"
+    sink._last_advance = time.monotonic() - 300
+
+    sink.put(StatusInfo.updating(qube, 25.0))
+
+    bar.set_postfix_str.assert_called_once_with("", refresh=False)
+    assert sink._quiet_note() == ""
+
+
+def test_agent_output_close_closes_bar_once() -> None:
+    _log, bar, sink = _bar_sink()
+
+    sink.close()
+    sink.close()
+
+    bar.close.assert_called_once_with()
+
+
+def test_make_progress_bar_skipped_when_stderr_not_a_tty(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        template_upgrade.sys.stderr, "isatty", lambda: False, raising=False
+    )
+    assert template_upgrade.make_progress_bar("desc") is None
+
+
+def test_make_progress_bar_on_a_tty(monkeypatch) -> None:
+    monkeypatch.setattr(
+        template_upgrade.sys.stderr, "isatty", lambda: True, raising=False
+    )
+    bar = template_upgrade.make_progress_bar("desc")
+    try:
+        assert bar is not None
+        assert bar.total == 100.0
+        # A half-hour bar has to survive the terminal being resized.
+        assert bar.dynamic_ncols
+    finally:
+        if bar is not None:
+            bar.close()
+
+
+def test_run_agent_closes_bar_even_on_failure(monkeypatch) -> None:
+    """The bar's in-place line must be finished before rollback/error output
+    prints, or the messages land on top of it."""
+    app = CloneApp()
+    add_template(app)
+    bar = MagicMock()
+    bar.n = 0.0
+    monkeypatch.setattr(
+        template_upgrade, "make_progress_bar", lambda *a, **kw: bar
+    )
+
+    def fake_update_qube(
+        qube, agent_args, **kwargs
+    ) -> tuple[str, ProcessResult]:
+        return qube.name, ProcessResult(EXIT.ERR_VM_UPDATE)
+
+    monkeypatch.setattr(template_upgrade, "update_qube", fake_update_qube)
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.ERR
+    bar.close.assert_called_once_with()
+
+
+def test_default_run_streams_output(monkeypatch, capsys) -> None:
+    """Agent lines stream to stdout by default, so a failure needs no
+    separate output replay."""
+    app = CloneApp()
+    add_template(app)
+
+    def fake_update_qube(qube, agent_args, **kwargs):
+        kwargs["status_notifier"].put(
+            FormatedLine(qube.name, "out", "Installing: bash")
+        )
+        return qube.name, ProcessResult(EXIT.OK)
+
+    monkeypatch.setattr(
+        template_upgrade, "make_progress_bar", lambda description: None
+    )
+    monkeypatch.setattr(template_upgrade, "update_qube", fake_update_qube)
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.OK
+    assert "Installing: bash" in capsys.readouterr().out
+
+
+# --log argument
+
+
+def test_log_level_is_case_insensitive() -> None:
+    app = CloneApp()
+    add_template(app)
+
+    retcode = template_upgrade.main(
+        ["--template", "fedora-41", "--dry-run", "--log", "debug"], app
+    )
+
+    assert retcode == EXIT.OK
+
+
+def test_invalid_log_level_is_a_usage_error(capsys) -> None:
+    """A bad --log value is an argparse error, not a raw ValueError from
+    Logger.setLevel."""
+    app = CloneApp()
+    add_template(app)
+
+    with pytest.raises(SystemExit) as excinfo:
+        template_upgrade.main(
+            ["--template", "fedora-41", "--log", "VERBOSE"], app
+        )
+
+    assert excinfo.value.code == 2
+    assert "invalid choice" in capsys.readouterr().err
+
+
+def test_keyboard_interrupt_returns_sigint(monkeypatch, capsys) -> None:
+    """Ctrl+C during the upgrade returns 130 as the manpage documents and
+    warns that the clone may remain."""
+    app = CloneApp()
+    add_template(app)
+
+    def interrupt(self) -> None:
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(
+        template_upgrade.TemplateUpgrader, "run_agent", interrupt
+    )
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.SIGINT == 130
+    assert "interrupted" in capsys.readouterr().err
+    # The clone is left for the user to inspect or remove.
+    assert "fedora-42" in app.domains

--- a/vmupdate/tests/test_template_upgrade.py
+++ b/vmupdate/tests/test_template_upgrade.py
@@ -324,9 +324,7 @@ def test_upgraded_template_keeps_every_feature_qvm_template_reads(
     ):
         assert required in features, required
     # qvm-template parses this one with strptime(DATE_FMT).
-    datetime.strptime(
-        features["template-buildtime"], template_upgrade.DATE_FMT
-    )
+    datetime.strptime(features["template-buildtime"], template_upgrade.DATE_FMT)
 
 
 def test_custom_template_description_left_untouched(monkeypatch) -> None:
@@ -355,9 +353,7 @@ def test_standalone_without_template_name_left_alone(
         template_upgrade.TemplateUpgrader, "run_agent", lambda self: None
     )
 
-    retcode = template_upgrade.main(
-        ["--template", "fedora-41-standalone"], app
-    )
+    retcode = template_upgrade.main(["--template", "fedora-41-standalone"], app)
 
     assert retcode == EXIT.OK
     assert (
@@ -381,9 +377,7 @@ def test_standalone_template_name_left_untouched(monkeypatch) -> None:
         template_upgrade.TemplateUpgrader, "run_agent", lambda self: None
     )
 
-    retcode = template_upgrade.main(
-        ["--template", "fedora-41-standalone"], app
-    )
+    retcode = template_upgrade.main(["--template", "fedora-41-standalone"], app)
 
     assert retcode == EXIT.OK
     clone = app.domains["fedora-42-standalone"]
@@ -653,9 +647,7 @@ def test_setup_logging_is_idempotent(tmp_path, monkeypatch) -> None:
     assert log2.propagate is False
 
 
-def test_setup_logging_tolerates_missing_log_dir(
-    tmp_path, monkeypatch
-) -> None:
+def test_setup_logging_tolerates_missing_log_dir(tmp_path, monkeypatch) -> None:
     """A missing log directory degrades to stderr-only, not a crash."""
     monkeypatch.setattr(template_upgrade, "setup_logging", _REAL_SETUP_LOGGING)
     monkeypatch.setattr(
@@ -676,9 +668,7 @@ def test_setup_logging_tolerates_missing_log_dir(
     )
 
 
-def test_setup_logging_agent_logger_is_file_only(
-    tmp_path, monkeypatch
-) -> None:
+def test_setup_logging_agent_logger_is_file_only(tmp_path, monkeypatch) -> None:
     """Agent output logger should only write to file, not stderr."""
     monkeypatch.setattr(template_upgrade, "setup_logging", _REAL_SETUP_LOGGING)
     monkeypatch.setattr(
@@ -708,9 +698,7 @@ def test_agent_output_logs_progress_ticks_at_debug() -> None:
     sink.put(StatusInfo.updating(qube, 42.5))
     sink.put(FormatedLine("fedora-42-xfce", "out", "hello"))
 
-    log.debug.assert_called_once_with(
-        "%s progress: %s", "fedora-42-xfce", 42.5
-    )
+    log.debug.assert_called_once_with("%s progress: %s", "fedora-42-xfce", 42.5)
     log.info.assert_called_once()
 
 
@@ -810,9 +798,7 @@ def test_lines_stream_to_stdout_while_ticks_drive_the_bar(capsys) -> None:
         sink.put(StatusInfo.updating(qube, float(i + 1)))
         for j in range(lines_per_tick):
             sink.put(
-                FormatedLine(
-                    "fedora-42-xfce", "out", f"Installing pkg-{i}-{j}"
-                )
+                FormatedLine("fedora-42-xfce", "out", f"Installing pkg-{i}-{j}")
             )
     sink.close()
 

--- a/vmupdate/tests/test_template_upgrade.py
+++ b/vmupdate/tests/test_template_upgrade.py
@@ -1066,6 +1066,113 @@ def test_default_run_streams_output(monkeypatch, capsys) -> None:
     assert "Installing: bash" in capsys.readouterr().out
 
 
+# disk-space warning suppression around the agent run
+
+
+def _capture_disk_feature(captured, code=EXIT.OK):
+    """A fake update_qube that records the clone and the suppression
+    feature's value at the moment the agent runs."""
+
+    def fake_update_qube(
+        qube, agent_args, **kwargs
+    ) -> tuple[str, ProcessResult]:
+        captured["qube"] = qube
+        captured["during"] = qube.features.get(
+            template_upgrade.DISK_SPACE_NOTIFY_FEATURE
+        )
+        return qube.name, ProcessResult(code)
+
+    return fake_update_qube
+
+
+def test_disk_space_warning_suppressed_during_agent_run(monkeypatch) -> None:
+    """The clone's qui-disk-space warning is off while the agent runs and
+    the feature is absent again after a successful run."""
+    app = CloneApp()
+    add_template(app)
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        template_upgrade, "update_qube", _capture_disk_feature(captured)
+    )
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.OK
+    assert captured["during"] == "1"
+    clone = app.domains["fedora-42"]
+    assert template_upgrade.DISK_SPACE_NOTIFY_FEATURE not in clone.features
+
+
+def test_disk_space_warning_prior_value_restored(monkeypatch) -> None:
+    """A pre-existing feature value on the source (inherited by the clone)
+    is restored after the run instead of being deleted."""
+    app = CloneApp()
+    add_template(app, **{template_upgrade.DISK_SPACE_NOTIFY_FEATURE: "0"})
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        template_upgrade, "update_qube", _capture_disk_feature(captured)
+    )
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.OK
+    assert captured["during"] == "1"
+    clone = app.domains["fedora-42"]
+    assert clone.features[template_upgrade.DISK_SPACE_NOTIFY_FEATURE] == "0"
+
+
+def test_disk_space_warning_restored_on_agent_failure(monkeypatch) -> None:
+    """The finally path restores the feature even when the agent fails."""
+    app = CloneApp()
+    add_template(app)
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        template_upgrade,
+        "update_qube",
+        _capture_disk_feature(captured, code=EXIT.ERR_VM_UPDATE),
+    )
+
+    retcode = template_upgrade.main(
+        ["--template", "fedora-41", "--keep-new-on-failure"], app
+    )
+
+    assert retcode == EXIT.ERR
+    assert captured["during"] == "1"
+    clone = captured["qube"]
+    assert template_upgrade.DISK_SPACE_NOTIFY_FEATURE not in clone.features
+
+
+def test_disk_space_suppression_failure_does_not_block_agent(
+    monkeypatch,
+) -> None:
+    """If setting the feature raises, the agent still runs and the upgrade succeeds."""
+
+    class BoomFeatures(dict):
+        def __setitem__(self, key, value) -> None:
+            if key == template_upgrade.DISK_SPACE_NOTIFY_FEATURE:
+                raise qubesadmin.exc.QubesException("features unavailable")
+            super().__setitem__(key, value)
+
+    class BoomApp(CloneApp):
+        def clone_vm(self, source_vm, new_name) -> _TestVM:
+            clone = super().clone_vm(source_vm, new_name)
+            clone.features = BoomFeatures(clone.features)
+            return clone
+
+    app = BoomApp()
+    add_template(app)
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        template_upgrade, "update_qube", _capture_disk_feature(captured)
+    )
+
+    retcode = template_upgrade.main(["--template", "fedora-41"], app)
+
+    assert retcode == EXIT.OK
+    assert captured["during"] is None  # never got suppressed
+    assert captured["qube"].name == "fedora-42"
+
+
 # --log argument
 
 

--- a/vmupdate/tests/test_version_upgrade_agent.py
+++ b/vmupdate/tests/test_version_upgrade_agent.py
@@ -26,7 +26,7 @@ The agent modules use absolute ``source.*`` imports because inside a qube
 they run with the agent directory as the top-level package root (see
 ``entrypoint.py``). We mirror that here by putting the agent directory on
 ``sys.path`` so the agent can be imported and unit-tested in isolation, with
-``subprocess`` fully mocked -- no real dnf is ever invoked.
+``subprocess`` fully mocked -- no real package manager is ever invoked.
 """
 
 import os
@@ -47,6 +47,7 @@ if _AGENT_DIR not in sys.path:
 # pylint: disable=wrong-import-position
 import entrypoint
 from source.dnf.dnf_cli import DNFCLI
+from source.apt.apt_cli import APTCLI
 from source.common.package_manager import PackageManager, AgentType
 from source.common.process_result import ProcessResult
 from source.common.exit_codes import EXIT
@@ -130,9 +131,9 @@ def test_version_upgrade_refuses_non_numeric_target():
 @pytest.mark.parametrize(
     "target,current",
     [
-        ("41", "41"),  # no-op
-        ("40", "41"),  # downgrade
-        ("43", "41"),  # two-step jump
+        ("41", "41"),
+        ("40", "41"),
+        ("43", "41"),
     ],
 )
 def test_version_upgrade_enforces_single_step(target, current):
@@ -200,12 +201,10 @@ def test_version_upgrade_maps_distro_sync_failure():
     assert code == EXIT.ERR_VM_UPDATE
 
 
-# Base class -- loud fail-closed default, covers Debian/apt + Arch
+# Base class -- fail-closed default for families without an implementation
 
 
 def test_base_version_upgrade_fails_loud():
-    # Families without a real implementation must raise NotImplementedError
-    # so callers can decide how to log and map the unsupported path.
     mgr = PackageManager(logging.NullHandler(), logging.DEBUG, AgentType.VM)
     with pytest.raises(NotImplementedError, match="not implemented"):
         mgr._release_upgrade("42")
@@ -298,3 +297,296 @@ def test_entrypoint_runs_normal_update_without_flag():
     pkg_mng.upgrade.assert_called_once()
     pkg_mng.version_upgrade.assert_not_called()
     assert code == EXIT.OK
+
+
+# APTCLI Debian release-upgrade path
+
+
+def test_apt_api_refresh_reloads_sources_before_update():
+    apt_api = pytest.importorskip("source.apt.apt_api")
+    mgr = apt_api.APT.__new__(apt_api.APT)
+    mgr.wait_for_lock = MagicMock()
+    mgr.apt_cache = MagicMock()
+    mgr.progress = MagicMock()
+    mgr.log = MagicMock()
+    calls = []
+
+    mgr.apt_cache.open.side_effect = lambda: calls.append("open")
+
+    def update(*_args, **_kwargs):
+        calls.append("update")
+        return True
+
+    mgr.apt_cache.update.side_effect = update
+
+    result = mgr.refresh(hard_fail=True)
+
+    assert result.code == EXIT.OK
+    assert calls == ["open", "update", "open"]
+
+
+def make_apt_cli():
+    """Build an APTCLI without requiring a real apt on the host."""
+    return APTCLI(logging.NullHandler(), logging.DEBUG, AgentType.VM)
+
+
+def debian_os_data(release="12", codename="bookworm"):
+    return {
+        "id": "debian",
+        "os_family": "Debian",
+        "release": release,
+        "codename": codename,
+    }
+
+
+# APTCLI in-qube guard (single-step, Debian-only, codenames must resolve)
+
+
+def _apt_guard(os_data, target):
+    return make_apt_cli()._verify_release_upgrade(target, os_data)
+
+
+def test_apt_guard_refuses_non_debian_family():
+    assert _apt_guard(fedora_os_data("41"), "42").code == EXIT.ERR_VM_UPDATE
+
+
+def test_apt_guard_refuses_non_numeric_target():
+    result = _apt_guard(debian_os_data("12", "bookworm"), "trixie")
+    assert result.code == EXIT.ERR_VM_UPDATE
+
+
+@pytest.mark.parametrize(
+    "target,current",
+    [
+        ("12", "12"),
+        ("11", "12"),
+        ("14", "12"),
+    ],
+)
+def test_apt_guard_enforces_single_step(target, current):
+    result = _apt_guard(debian_os_data(current, "bookworm"), target)
+    assert result.code == EXIT.ERR_VM_UPDATE
+
+
+def test_apt_guard_refuses_unknown_target_codename():
+    # 14->15 is a single step, but 15 is not in DEBIAN_CODENAMES yet
+    result = _apt_guard(debian_os_data("14", "forky"), "15")
+    assert result.code == EXIT.ERR_VM_UPDATE
+
+
+def test_apt_guard_refuses_missing_codename():
+    os_data = {"id": "debian", "os_family": "Debian", "release": "12"}
+    assert _apt_guard(os_data, "13").code == EXIT.ERR_VM_UPDATE
+
+
+def test_apt_guard_passes_for_single_step_debian():
+    assert _apt_guard(debian_os_data("12", "bookworm"), "13").code == EXIT.OK
+
+
+# APTCLI._release_upgrade composition (apt mocked at the step level)
+
+
+def _record_apt_steps(mgr, calls, fail_on=None, cleanup_fail=False):
+    """Replace the composed steps with recorders."""
+
+    def refresh(hard_fail):
+        calls.append("refresh")
+        return ProcessResult(EXIT.ERR if fail_on == "refresh" else EXIT.OK)
+
+    def upgrade_internal(remove_obsolete):
+        calls.append("upgrade")
+        return ProcessResult(EXIT.ERR if fail_on == "upgrade" else EXIT.OK)
+
+    def dist_upgrade():
+        calls.append("dist-upgrade")
+        return ProcessResult(EXIT.ERR if fail_on == "dist-upgrade" else EXIT.OK)
+
+    def rewrite(old_codename, new_codename):
+        calls.append(f"rewrite:{old_codename}->{new_codename}")
+        return ProcessResult(EXIT.ERR if fail_on == "rewrite" else EXIT.OK)
+
+    def remove_obsolete_kernels():
+        calls.append("kernel-cleanup")
+        return ProcessResult(EXIT.ERR_VM_CLEANUP if cleanup_fail else EXIT.OK)
+
+    mgr.refresh = refresh
+    mgr.upgrade_internal = upgrade_internal
+    mgr._dist_upgrade = dist_upgrade
+    mgr._rewrite_sources = rewrite
+    mgr.remove_obsolete_kernels = remove_obsolete_kernels
+
+
+def test_apt_release_upgrade_happy_path_order(capsys):
+    mgr = make_apt_cli()
+    calls = []
+    _record_apt_steps(mgr, calls)
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        side_effect=[
+            debian_os_data("12", "bookworm"),
+            debian_os_data("13", "trixie"),
+        ],
+    ):
+        code = mgr.version_upgrade("13")
+
+    assert code == EXIT.OK
+    assert calls == [
+        "refresh",
+        "upgrade",
+        "rewrite:bookworm->trixie",
+        "refresh",
+        "upgrade",
+        "dist-upgrade",
+        "kernel-cleanup",
+    ]
+    # the QubeConnection progress contract: bare floats, terminated by 100.00
+    assert capsys.readouterr().err.split() == ["0.00", "100.00"]
+
+
+def test_apt_release_upgrade_survives_kernel_cleanup_failure(capsys):
+    # a successful release bump must not be discarded because the trailing
+    # best-effort obsolete-kernel cleanup failed
+    mgr = make_apt_cli()
+    calls = []
+    _record_apt_steps(mgr, calls, cleanup_fail=True)
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        side_effect=[
+            debian_os_data("12", "bookworm"),
+            debian_os_data("13", "trixie"),
+        ],
+    ):
+        code = mgr.version_upgrade("13")
+
+    assert code == EXIT.OK
+    assert calls[-1] == "kernel-cleanup"
+    assert capsys.readouterr().err.split() == ["0.00", "100.00"]
+
+
+def test_apt_release_upgrade_bails_before_rewrite_when_update_fails(capsys):
+    mgr = make_apt_cli()
+    calls = []
+    _record_apt_steps(mgr, calls, fail_on="refresh")
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        return_value=debian_os_data("12", "bookworm"),
+    ):
+        code = mgr.version_upgrade("13")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    # first apt-get update fails: sources never rewritten, no dist-upgrade
+    assert calls == ["refresh"]
+    assert capsys.readouterr().err.split() == ["0.00"]
+
+
+def test_apt_release_upgrade_maps_dist_upgrade_failure(capsys):
+    mgr = make_apt_cli()
+    calls = []
+    _record_apt_steps(mgr, calls, fail_on="dist-upgrade")
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        return_value=debian_os_data("12", "bookworm"),
+    ):
+        code = mgr.version_upgrade("13")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    assert calls[-1] == "dist-upgrade"
+    assert "100.00" not in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "actual",
+    [
+        debian_os_data("12", "bookworm"),
+        debian_os_data("13", "bookworm"),
+    ],
+)
+def test_apt_release_upgrade_verifies_target_release(actual, capsys):
+    mgr = make_apt_cli()
+    calls = []
+    _record_apt_steps(mgr, calls)
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        side_effect=[debian_os_data("12", "bookworm"), actual],
+    ):
+        code = mgr.version_upgrade("13")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    assert calls[-1] == "dist-upgrade"
+    assert "kernel-cleanup" not in calls
+    assert "100.00" not in capsys.readouterr().err
+
+
+def test_apt_release_upgrade_guard_failure_short_circuits(capsys):
+    mgr = make_apt_cli()
+    calls = []
+    _record_apt_steps(mgr, calls)
+    with patch(
+        "source.apt.apt_cli.get_os_data", return_value=fedora_os_data("41")
+    ):
+        code = mgr.version_upgrade("42")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    assert calls == []  # no apt call, no rewrite, no progress
+    assert capsys.readouterr().err.split() == []
+
+
+# apt sources codename rewrite
+
+
+def test_apt_rewrites_list_and_deb822_sources(tmp_path):
+    mgr = make_apt_cli()
+    listd = tmp_path / "sources.list.d"
+    listd.mkdir()
+    main = tmp_path / "sources.list"
+    main.write_text("deb http://deb.debian.org/debian bookworm main\n")
+    qubes = listd / "qubes-r4.list"
+    qubes.write_text(
+        "deb [arch=amd64] https://deb.qubes-os.org/r4.2/vm bookworm main\n"
+    )
+    deb822 = listd / "debian.sources"
+    deb822.write_text(
+        "Types: deb\n"
+        "URIs: http://deb.debian.org/debian\n"
+        "Suites: bookworm bookworm-security bookworm-updates\n"
+        "Components: main\n"
+    )
+    untouched = listd / "thirdparty.list"
+    untouched.write_text("deb http://example.com/repo stable main\n")
+    before = untouched.read_text()
+
+    globs = (
+        str(main),
+        str(tmp_path / "absent.list"),  # missing files are skipped
+        str(listd / "*.list"),
+        str(listd / "*.sources"),
+    )
+    with patch.object(APTCLI, "APT_SOURCE_GLOBS", globs):
+        result = mgr._rewrite_sources("bookworm", "trixie")
+
+    assert result.code == EXIT.OK
+    assert main.read_text() == "deb http://deb.debian.org/debian trixie main\n"
+    assert "trixie" in qubes.read_text() and "bookworm" not in qubes.read_text()
+    assert "Suites: trixie trixie-security trixie-updates" in deb822.read_text()
+    # a file with no codename occurrence is left byte-identical
+    assert untouched.read_text() == before
+    # the atomic write-then-rename leaves no temp files behind
+    assert list(tmp_path.rglob("*.tmp")) == []
+
+
+def test_apt_rewrite_refuses_when_no_source_uses_the_codename(tmp_path):
+    # symbolically addressed sources (e.g. `stable`) never mention the
+    # codename: the rewrite would be a no-op, so refuse rather than let the
+    # qube silently stay on the old release while dom0 stamps it upgraded
+    mgr = make_apt_cli()
+    listd = tmp_path / "sources.list.d"
+    listd.mkdir()
+    main = tmp_path / "sources.list"
+    main.write_text("deb http://deb.debian.org/debian stable main\n")
+    before = main.read_text()
+    globs = (str(main), str(listd / "*.list"), str(listd / "*.sources"))
+    with patch.object(APTCLI, "APT_SOURCE_GLOBS", globs):
+        result = mgr._rewrite_sources("bookworm", "trixie")
+
+    assert result.code == EXIT.ERR_VM_UPDATE
+    assert main.read_text() == before  # nothing written

--- a/vmupdate/tests/test_version_upgrade_agent.py
+++ b/vmupdate/tests/test_version_upgrade_agent.py
@@ -1,0 +1,300 @@
+#!/usr/bin/python3
+# coding=utf-8
+#
+# The Qubes OS Project, https://www.qubes-os.org
+#
+# Copyright (C) 2026  Qubes OS contributors
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+"""
+Unit tests for the in-VM distribution version-upgrade agent path.
+
+The agent modules use absolute ``source.*`` imports because inside a qube
+they run with the agent directory as the top-level package root (see
+``entrypoint.py``). We mirror that here by putting the agent directory on
+``sys.path`` so the agent can be imported and unit-tested in isolation, with
+``subprocess`` fully mocked -- no real dnf is ever invoked.
+"""
+
+import os
+import sys
+import logging
+import argparse
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+_AGENT_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir, "agent")
+)
+if _AGENT_DIR not in sys.path:
+    sys.path.insert(0, _AGENT_DIR)
+
+# pylint: disable=wrong-import-position
+import entrypoint
+from source.dnf.dnf_cli import DNFCLI
+from source.common.package_manager import PackageManager, AgentType
+from source.common.process_result import ProcessResult
+from source.common.exit_codes import EXIT
+from source.args import AgentArgs
+
+
+def _expected_sync_cmd(target):
+    return (
+        "dnf",
+        f"--releasever={target}",
+        "distro-sync",
+        "--best",
+        "--allowerasing",
+        "--assumeyes",
+    )
+
+
+def make_dnf_cli():
+    """Build a DNFCLI without requiring a real dnf binary on the host."""
+    with patch("source.dnf.dnf_cli.shutil.which", return_value="/usr/bin/dnf"):
+        return DNFCLI(logging.NullHandler(), logging.DEBUG, AgentType.VM)
+
+
+def fedora_os_data(release="41"):
+    return {"id": "fedora", "os_family": "RedHat", "release": release}
+
+
+# DNFCLI._release_upgrade -- happy path
+
+
+def test_version_upgrade_runs_clean_then_distro_sync():
+    mgr = make_dnf_cli()
+    calls = []
+
+    def fake_run_cmd(cmd, realtime=True):
+        calls.append((tuple(cmd), realtime))
+        return ProcessResult(EXIT.OK)
+
+    with patch.object(mgr, "run_cmd", side_effect=fake_run_cmd), patch(
+        "source.dnf.dnf_cli.get_os_data", return_value=fedora_os_data("41")
+    ):
+        code = mgr.version_upgrade("42")
+
+    assert code == EXIT.OK
+    # Old-release cache is wiped (captured, not streamed) before the bump.
+    assert calls[0] == (("dnf", "clean", "all"), False)
+    sync_cmd, sync_realtime = calls[1]
+    assert sync_cmd == _expected_sync_cmd("42")
+    # distro-sync streams in real time so dom0 sees live output.
+    assert sync_realtime is True
+
+
+def test_version_upgrade_emits_progress_milestones(capsys):
+    mgr = make_dnf_cli()
+    with patch.object(
+        mgr, "run_cmd", return_value=ProcessResult(EXIT.OK)
+    ), patch(
+        "source.dnf.dnf_cli.get_os_data", return_value=fedora_os_data("41")
+    ):
+        mgr.version_upgrade("42")
+
+    # The progress contract QubeConnection._collect_stderr parses: bare floats
+    # terminated by 100.00.
+    assert capsys.readouterr().err.split() == ["0.00", "100.00"]
+
+
+# DNFCLI._release_upgrade -- in-qube re-verification (single-step only)
+
+
+def test_version_upgrade_refuses_non_numeric_target():
+    mgr = make_dnf_cli()
+    with patch.object(mgr, "run_cmd") as run_cmd, patch(
+        "source.dnf.dnf_cli.get_os_data", return_value=fedora_os_data("41")
+    ):
+        code = mgr.version_upgrade("bookworm")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    run_cmd.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "target,current",
+    [
+        ("41", "41"),  # no-op
+        ("40", "41"),  # downgrade
+        ("43", "41"),  # two-step jump
+    ],
+)
+def test_version_upgrade_enforces_single_step(target, current):
+    mgr = make_dnf_cli()
+    with patch.object(mgr, "run_cmd") as run_cmd, patch(
+        "source.dnf.dnf_cli.get_os_data",
+        return_value=fedora_os_data(current),
+    ):
+        code = mgr.version_upgrade(target)
+
+    assert code == EXIT.ERR_VM_UPDATE
+    run_cmd.assert_not_called()
+
+
+def test_version_upgrade_allows_dotted_current_release():
+    # VERSION_ID like "41.20240101" should compare on the major component.
+    mgr = make_dnf_cli()
+    with patch.object(
+        mgr, "run_cmd", return_value=ProcessResult(EXIT.OK)
+    ) as run_cmd, patch(
+        "source.dnf.dnf_cli.get_os_data",
+        return_value=fedora_os_data("41.20240101"),
+    ):
+        code = mgr.version_upgrade("42")
+
+    assert code == EXIT.OK
+    assert run_cmd.call_count == 2
+
+
+# DNFCLI._release_upgrade -- failure mapping
+
+
+def test_version_upgrade_bails_when_clean_fails():
+    mgr = make_dnf_cli()
+    calls = []
+
+    def fake_run_cmd(cmd, realtime=True):
+        calls.append(tuple(cmd))
+        return ProcessResult(3)  # clean all fails
+
+    with patch.object(mgr, "run_cmd", side_effect=fake_run_cmd), patch(
+        "source.dnf.dnf_cli.get_os_data", return_value=fedora_os_data("41")
+    ):
+        code = mgr.version_upgrade("42")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    # distro-sync is never attempted once the cache wipe fails.
+    assert calls == [("dnf", "clean", "all")]
+
+
+def test_version_upgrade_maps_distro_sync_failure():
+    mgr = make_dnf_cli()
+
+    def fake_run_cmd(cmd, realtime=True):
+        if "distro-sync" in cmd:
+            return ProcessResult(7)  # arbitrary non-zero dnf failure
+        return ProcessResult(EXIT.OK)
+
+    with patch.object(mgr, "run_cmd", side_effect=fake_run_cmd), patch(
+        "source.dnf.dnf_cli.get_os_data", return_value=fedora_os_data("41")
+    ):
+        code = mgr.version_upgrade("42")
+
+    # Any non-zero is normalised to a dom0-handled VM error code.
+    assert code == EXIT.ERR_VM_UPDATE
+
+
+# Base class -- loud fail-closed default, covers Debian/apt + Arch
+
+
+def test_base_version_upgrade_fails_loud():
+    # Families without a real implementation must raise NotImplementedError
+    # so callers can decide how to log and map the unsupported path.
+    mgr = PackageManager(logging.NullHandler(), logging.DEBUG, AgentType.VM)
+    with pytest.raises(NotImplementedError, match="not implemented"):
+        mgr._release_upgrade("42")
+    with pytest.raises(NotImplementedError, match="not implemented"):
+        mgr.version_upgrade("42")
+
+
+# Agent CLI surface -- args round-trip
+
+
+def _parse_agent_args(argv):
+    parser = argparse.ArgumentParser()
+    AgentArgs.add_arguments(parser)
+    return parser.parse_args(argv)
+
+
+def test_version_upgrade_flag_round_trips_through_cli_args():
+    args = _parse_agent_args(["--version-upgrade", "42"])
+    assert args.version_upgrade == "42"
+
+    cli = AgentArgs.to_cli_args(args)
+    assert "--version-upgrade" in cli
+    assert cli[cli.index("--version-upgrade") + 1] == "42"
+
+
+def test_version_upgrade_flag_absent_by_default():
+    args = _parse_agent_args([])
+    assert args.version_upgrade is None
+
+    cli = AgentArgs.to_cli_args(args)
+    assert "--version-upgrade" not in cli
+    # Regression guard: a None-valued option must never leak a bare token.
+    assert None not in cli
+
+
+# Entrypoint dispatch
+
+
+def _patched_entrypoint(pkg_mng):
+    """Common patches so entrypoint.main runs without a real qube/logs."""
+    fake_logs = (MagicMock(), MagicMock(), logging.DEBUG, "", "")
+    return (
+        patch("entrypoint.init_logs", return_value=fake_logs),
+        patch("entrypoint.get_os_data", return_value=fedora_os_data("41")),
+        patch("entrypoint.get_package_manager", return_value=pkg_mng),
+        patch("entrypoint.os.system"),
+    )
+
+
+def test_entrypoint_dispatches_to_version_upgrade():
+    pkg_mng = MagicMock()
+    pkg_mng.version_upgrade.return_value = EXIT.OK
+    pkg_mng.clean.return_value = EXIT.OK
+
+    patches = _patched_entrypoint(pkg_mng)
+    with patches[0], patches[1], patches[2], patches[3]:
+        code = entrypoint.main(["--version-upgrade", "42"])
+
+    pkg_mng.version_upgrade.assert_called_once_with("42", print_streams=False)
+    pkg_mng.upgrade.assert_not_called()
+    assert code == EXIT.OK
+
+
+def test_entrypoint_maps_missing_version_upgrade_to_handled_error(capsys):
+    pkg_mng = MagicMock()
+    pkg_mng.version_upgrade.side_effect = NotImplementedError(
+        "Distribution version upgrade is not implemented for this package manager."
+    )
+    pkg_mng.clean.return_value = EXIT.OK
+
+    patches = _patched_entrypoint(pkg_mng)
+    with patches[0], patches[1], patches[2], patches[3]:
+        code = entrypoint.main(["--version-upgrade", "42"])
+
+    pkg_mng.version_upgrade.assert_called_once_with("42", print_streams=False)
+    pkg_mng.upgrade.assert_not_called()
+    assert code == EXIT.ERR_VM_UPDATE
+    assert "not implemented" in capsys.readouterr().err
+
+
+def test_entrypoint_runs_normal_update_without_flag():
+    pkg_mng = MagicMock()
+    pkg_mng.upgrade.return_value = EXIT.OK
+    pkg_mng.clean.return_value = EXIT.OK
+
+    patches = _patched_entrypoint(pkg_mng)
+    with patches[0], patches[1], patches[2], patches[3]:
+        code = entrypoint.main([])
+
+    pkg_mng.upgrade.assert_called_once()
+    pkg_mng.version_upgrade.assert_not_called()
+    assert code == EXIT.OK

--- a/vmupdate/tests/test_version_upgrade_agent.py
+++ b/vmupdate/tests/test_version_upgrade_agent.py
@@ -44,7 +44,7 @@ _AGENT_DIR = os.path.abspath(
 if _AGENT_DIR not in sys.path:
     sys.path.insert(0, _AGENT_DIR)
 
-# pylint: disable=wrong-import-position
+# pylint: disable=wrong-import-position,protected-access
 import entrypoint
 from source.dnf.dnf_cli import DNFCLI
 from source.apt.apt_cli import APTCLI
@@ -112,6 +112,34 @@ def test_version_upgrade_emits_progress_milestones(capsys):
     # The progress contract QubeConnection._collect_stderr parses: bare floats
     # terminated by 100.00.
     assert capsys.readouterr().err.split() == ["0.00", "100.00"]
+
+
+def test_version_upgrade_release_bump_goes_through_distro_sync_seam():
+    """The release bump must route through `_distro_sync`: the dnf/dnf5 API
+    subclasses override that method to report fine-grained progress, so the
+    base flow may not bypass it."""
+    mgr = make_dnf_cli()
+    seam_calls = []
+
+    def fake_distro_sync(target):
+        seam_calls.append(target)
+        return ProcessResult(EXIT.OK)
+
+    with patch.object(
+        mgr, "run_cmd", return_value=ProcessResult(EXIT.OK)
+    ) as run_cmd, patch.object(
+        mgr, "_distro_sync", side_effect=fake_distro_sync
+    ), patch(
+        "source.dnf.dnf_cli.get_os_data", return_value=fedora_os_data("41")
+    ):
+        code = mgr.version_upgrade("42")
+
+    assert code == EXIT.OK
+    assert seam_calls == ["42"]
+    # only the cache wipe still goes through run_cmd
+    assert [tuple(c.args[0]) for c in run_cmd.call_args_list] == [
+        ("dnf", "clean", "all")
+    ]
 
 
 # DNFCLI._release_upgrade -- in-qube re-verification (single-step only)
@@ -327,7 +355,16 @@ def test_apt_api_refresh_reloads_sources_before_update():
 
 def make_apt_cli():
     """Build an APTCLI without requiring a real apt on the host."""
-    return APTCLI(logging.NullHandler(), logging.DEBUG, AgentType.VM)
+    mgr = APTCLI(logging.NullHandler(), logging.DEBUG, AgentType.VM)
+    codenames = {
+        "11": "bullseye",
+        "12": "bookworm",
+        "13": "trixie",
+        "14": "forky",
+        "15": "duke",
+    }
+    mgr._debian_codename = codenames.get
+    return mgr
 
 
 def debian_os_data(release="12", codename="bookworm"):
@@ -339,15 +376,17 @@ def debian_os_data(release="12", codename="bookworm"):
     }
 
 
-# APTCLI in-qube guard (single-step, Debian-only, codenames must resolve)
+# APTCLI in-qube guard (single-step, current codename must be present)
 
 
 def _apt_guard(os_data, target):
     return make_apt_cli()._verify_release_upgrade(target, os_data)
 
 
-def test_apt_guard_refuses_non_debian_family():
-    assert _apt_guard(fedora_os_data("41"), "42").code == EXIT.ERR_VM_UPDATE
+def test_apt_guard_does_not_recheck_os_family():
+    os_data = debian_os_data("12", "bookworm")
+    os_data["os_family"] = "Unknown"
+    assert _apt_guard(os_data, "13").code == EXIT.OK
 
 
 def test_apt_guard_refuses_non_numeric_target():
@@ -368,12 +407,6 @@ def test_apt_guard_enforces_single_step(target, current):
     assert result.code == EXIT.ERR_VM_UPDATE
 
 
-def test_apt_guard_refuses_unknown_target_codename():
-    # 14->15 is a single step, but 15 is not in DEBIAN_CODENAMES yet
-    result = _apt_guard(debian_os_data("14", "forky"), "15")
-    assert result.code == EXIT.ERR_VM_UPDATE
-
-
 def test_apt_guard_refuses_missing_codename():
     os_data = {"id": "debian", "os_family": "Debian", "release": "12"}
     assert _apt_guard(os_data, "13").code == EXIT.ERR_VM_UPDATE
@@ -381,6 +414,19 @@ def test_apt_guard_refuses_missing_codename():
 
 def test_apt_guard_passes_for_single_step_debian():
     assert _apt_guard(debian_os_data("12", "bookworm"), "13").code == EXIT.OK
+
+
+def test_apt_reads_codename_from_distro_info(tmp_path):
+    releases = tmp_path / "debian.csv"
+    releases.write_text(
+        "version,codename,series,created,release,eol\n"
+        "14,Forky,forky,2025-08-09,,\n"
+        "15,Duke,duke,2027-08-01,,\n"
+    )
+
+    with patch.object(APTCLI, "DEBIAN_RELEASES_FILE", str(releases)):
+        assert APTCLI._debian_codename("15") == "duke"
+        assert APTCLI._debian_codename("16") is None
 
 
 # APTCLI._release_upgrade composition (apt mocked at the step level)
@@ -522,13 +568,45 @@ def test_apt_release_upgrade_guard_failure_short_circuits(capsys):
     calls = []
     _record_apt_steps(mgr, calls)
     with patch(
-        "source.apt.apt_cli.get_os_data", return_value=fedora_os_data("41")
+        "source.apt.apt_cli.get_os_data",
+        return_value=debian_os_data("12", ""),
     ):
-        code = mgr.version_upgrade("42")
+        code = mgr.version_upgrade("13")
 
     assert code == EXIT.ERR_VM_UPDATE
-    assert calls == []  # no apt call, no rewrite, no progress
-    assert capsys.readouterr().err.split() == []
+    assert not calls  # no apt call, no rewrite
+    assert not capsys.readouterr().err  # no progress emitted
+
+
+def test_apt_release_upgrade_refuses_unknown_target_codename(capsys):
+    mgr = make_apt_cli()
+    calls = []
+    _record_apt_steps(mgr, calls)
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        return_value=debian_os_data("15", "duke"),
+    ):
+        code = mgr.version_upgrade("16")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    assert not calls
+    assert not capsys.readouterr().err
+
+
+def test_apt_release_upgrade_refuses_unreadable_release_data(capsys):
+    mgr = make_apt_cli()
+    mgr._debian_codename = MagicMock(side_effect=OSError("missing"))
+    calls = []
+    _record_apt_steps(mgr, calls)
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        return_value=debian_os_data("12", "bookworm"),
+    ):
+        code = mgr.version_upgrade("13")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    assert not calls
+    assert not capsys.readouterr().err
 
 
 # apt sources codename rewrite
@@ -571,7 +649,7 @@ def test_apt_rewrites_list_and_deb822_sources(tmp_path):
     # a file with no codename occurrence is left byte-identical
     assert untouched.read_text() == before
     # the atomic write-then-rename leaves no temp files behind
-    assert list(tmp_path.rglob("*.tmp")) == []
+    assert not list(tmp_path.rglob("*.tmp"))
 
 
 def test_apt_rewrite_refuses_when_no_source_uses_the_codename(tmp_path):
@@ -589,4 +667,7 @@ def test_apt_rewrite_refuses_when_no_source_uses_the_codename(tmp_path):
         result = mgr._rewrite_sources("bookworm", "trixie")
 
     assert result.code == EXIT.ERR_VM_UPDATE
+    assert result.err.endswith(
+        "no apt source references codename 'bookworm'; refusing upgrade."
+    )
     assert main.read_text() == before  # nothing written

--- a/vmupdate/tests/test_version_upgrade_agent.py
+++ b/vmupdate/tests/test_version_upgrade_agent.py
@@ -1021,6 +1021,9 @@ def test_dnf5_api_distro_sync_reports_preparation_phase(capsys) -> None:
     base.get_repo_sack.return_value = repo_sack
 
     transaction = MagicMock()
+    transaction.get_problems.return_value = (
+        dnf5_api.libdnf5.base.GoalProblem_NO_PROBLEM
+    )
     transaction.get_transaction_packages_count.return_value = 1
     transaction.check_gpg_signatures.return_value = True
     transaction.run.return_value = transaction.TransactionRunResult_SUCCESS
@@ -1050,6 +1053,41 @@ def test_dnf5_api_distro_sync_reports_preparation_phase(capsys) -> None:
     repo_sack.load_repos.assert_called_once()
     transaction.download.assert_called_once()
     transaction.run.assert_called_once()
+
+
+def test_dnf5_api_distro_sync_reports_resolution_failure() -> None:
+    """A failed solve with no transaction packages is an error, not a no-op."""
+    dnf5_api = pytest.importorskip("source.dnf.dnf5_api")
+    mgr = dnf5_api.DNF5.__new__(dnf5_api.DNF5)
+    mgr.progress = MagicMock()
+    mgr.log = MagicMock()
+
+    base = MagicMock()
+    transaction = MagicMock()
+    transaction.get_problems.return_value = (
+        dnf5_api.libdnf5.base.GoalProblem_SOLVER_ERROR
+    )
+    transaction.get_resolve_logs_as_strings.return_value = [
+        "installed rpmfusion-free-release requires system-release(43)"
+    ]
+    transaction.get_transaction_packages_count.return_value = 0
+    goal = MagicMock()
+    goal.resolve.return_value = transaction
+
+    with patch.object(
+        dnf5_api.libdnf5.base, "Base", return_value=base
+    ), patch.object(
+        dnf5_api.libdnf5.repo, "DownloadCallbacksUniquePtr"
+    ), patch.object(
+        dnf5_api, "Goal", return_value=goal
+    ):
+        result = mgr._distro_sync("44")
+
+    assert result.code == EXIT.ERR_VM_UPDATE
+    assert "Failed to resolve the distro-sync transaction" in result.err
+    assert "rpmfusion-free-release" in result.err
+    transaction.download.assert_not_called()
+    transaction.run.assert_not_called()
 
 
 def test_dnf5_fetch_progress_tolerates_unknown_sizes(capsys) -> None:

--- a/vmupdate/tests/test_version_upgrade_agent.py
+++ b/vmupdate/tests/test_version_upgrade_agent.py
@@ -61,9 +61,9 @@ from source.common.progress_reporter import (
 from source.args import AgentArgs
 
 
-def _expected_sync_cmd(target) -> tuple[str, ...]:
+def _expected_sync_cmd(package_manager: str, target: str) -> tuple[str, ...]:
     return (
-        "dnf",
+        package_manager,
         f"--releasever={target}",
         "distro-sync",
         "--best",
@@ -121,9 +121,9 @@ def test_version_upgrade_runs_clean_then_distro_sync() -> None:
 
     assert code == EXIT.OK
     # Old-release cache is wiped (captured, not streamed) before the bump.
-    assert calls[0] == (("dnf", "clean", "all"), False)
+    assert calls[0] == ((mgr.package_manager, "clean", "all"), False)
     sync_cmd, sync_realtime = calls[1]
-    assert sync_cmd == _expected_sync_cmd("42")
+    assert sync_cmd == _expected_sync_cmd(mgr.package_manager, "42")
     # distro-sync streams in real time so dom0 sees live output.
     assert sync_realtime is True
 
@@ -523,7 +523,7 @@ def test_version_upgrade_release_bump_goes_through_distro_sync_seam() -> None:
     assert seam_calls == ["42"]
     # only the cache wipe still goes through run_cmd
     assert [tuple(c.args[0]) for c in run_cmd.call_args_list] == [
-        ("dnf", "clean", "all")
+        (mgr.package_manager, "clean", "all")
     ]
 
 
@@ -594,7 +594,7 @@ def test_version_upgrade_bails_when_clean_fails() -> None:
 
     assert code == EXIT.ERR_VM_UPDATE
     # distro-sync is never attempted once the cache wipe fails.
-    assert calls == [("dnf", "clean", "all")]
+    assert calls == [(mgr.package_manager, "clean", "all")]
 
 
 def test_version_upgrade_maps_distro_sync_failure() -> None:
@@ -1055,7 +1055,7 @@ def test_dnf5_api_distro_sync_reports_preparation_phase(capsys) -> None:
     transaction.run.assert_called_once()
 
 
-def test_dnf5_api_distro_sync_reports_resolution_failure() -> None:
+def test_dnf5_api_distro_sync_reports_resolution_failure(capsys) -> None:
     """A failed solve with no transaction packages is an error, not a no-op."""
     dnf5_api = pytest.importorskip("source.dnf.dnf5_api")
     mgr = dnf5_api.DNF5.__new__(dnf5_api.DNF5)
@@ -1084,6 +1084,7 @@ def test_dnf5_api_distro_sync_reports_resolution_failure() -> None:
         result = mgr._distro_sync("44")
 
     assert result.code == EXIT.ERR_VM_UPDATE
+    assert "Failed to resolve package dependencies" in capsys.readouterr().out
     assert "Failed to resolve the distro-sync transaction" in result.err
     assert "rpmfusion-free-release" in result.err
     transaction.download.assert_not_called()

--- a/vmupdate/tests/test_version_upgrade_agent.py
+++ b/vmupdate/tests/test_version_upgrade_agent.py
@@ -340,7 +340,9 @@ def test_apt_release_upgrade_step_slices_match_the_measured_weights(
         mgr, "_set_progress_step", side_effect=lambda *a: recorded.append(a)
     ), patch.object(mgr, "refresh", side_effect=drive_step), patch.object(
         mgr, "upgrade_internal", side_effect=drive_step
-    ), patch.object(mgr, "_dist_upgrade", side_effect=drive_step), patch.object(
+    ), patch.object(
+        mgr, "_dist_upgrade", side_effect=drive_step
+    ), patch.object(
         mgr, "_rewrite_sources", side_effect=drive_step
     ), patch.object(
         mgr, "remove_obsolete_kernels", return_value=ProcessResult(EXIT.OK)
@@ -1105,6 +1107,7 @@ def test_dnf5_expect_bytes_ignores_a_useless_estimate() -> None:
     assert progress.download_total == 400.0
 
     progress.expect_bytes(100.0)  # an estimate below what we can see
+    progress.add_new_download(None, "pkg", 400.0)
     assert progress.download_total == 400.0
 
 

--- a/vmupdate/tests/test_version_upgrade_agent.py
+++ b/vmupdate/tests/test_version_upgrade_agent.py
@@ -239,6 +239,49 @@ def test_step_range_gives_the_whole_slice_to_the_active_phases() -> None:
     assert reporter.last_percent == 50.0
 
 
+def _zero_weight_reporter():
+    """Build a reporter whose phases all weigh nothing.
+
+    ProgressReporter.__init__ normalizes phase weights, so it cannot be
+    constructed directly at total weight 0; start from a valid reporter
+    and flatten the weights to reach set_step_range's degenerate case.
+    """
+    log = MagicMock()
+    emitted: list[float] = []
+    phases = (Progress(4, log), Progress(48, log), Progress(48, log))
+    reporter = ProgressReporter(*phases, callback=emitted.append)
+    for phase in phases:
+        phase.weight = 0
+    return reporter
+
+
+def test_step_range_splits_evenly_when_all_weights_are_zero() -> None:
+    """A degenerate reporter whose active phases all weigh nothing must
+    still hand out the slice: split it evenly instead of collapsing every
+    phase to a zero-width range at the slice start."""
+    reporter = _zero_weight_reporter()
+
+    reporter.set_step_range(10.0, 30.0, installs=True)
+    # update is collapsed onto the slice start and must stay silent,
+    # while fetch and upgrade split 10..30 evenly
+    reporter.update_progress.notify_callback(100)
+    assert reporter.last_percent == 0.0
+    reporter.fetch_progress.notify_callback(100)
+    assert reporter.last_percent == 20.0
+    reporter.upgrade_progress.notify_callback(100)
+    assert reporter.last_percent == 30.0
+
+
+def test_step_range_gives_whole_slice_to_a_single_zero_weight_phase() -> None:
+    """Same even-split rule for a refresh-only step over a zero-weight
+    update phase: the phase gets the entire slice."""
+    reporter = _zero_weight_reporter()
+
+    reporter.set_step_range(10.0, 30.0, installs=False)
+    reporter.update_progress.notify_callback(100)
+    assert reporter.last_percent == 30.0
+
+
 def test_apt_release_upgrade_bar_stays_below_100_throughout(
     apt_sources, capfd
 ) -> None:
@@ -279,6 +322,62 @@ def test_apt_release_upgrade_bar_stays_below_100_throughout(
     assert max(emitted) == RELEASE_UPGRADE_ALMOST_DONE
     # so the explicit milestone is redundant and only 100 is printed
     assert capfd.readouterr().err.split() == ["0.00", "100.00"]
+
+
+def test_apt_release_upgrade_step_slices_match_the_measured_weights(
+    apt_sources,
+) -> None:
+    """Pin each step's slice of the bar: the weights are 7/7/1/9/22/54
+    (shares of a measured debian-12 to 13 upgrade), scaled into
+    0..RELEASE_UPGRADE_ALMOST_DONE."""
+    mgr = make_apt_cli()
+    recorded: list[tuple[float, float, bool]] = []
+
+    def drive_step(*_args, **_kwargs) -> ProcessResult:
+        return ProcessResult(EXIT.OK)
+
+    with patch.object(
+        mgr, "_set_progress_step", side_effect=lambda *a: recorded.append(a)
+    ), patch.object(mgr, "refresh", side_effect=drive_step), patch.object(
+        mgr, "upgrade_internal", side_effect=drive_step
+    ), patch.object(mgr, "_dist_upgrade", side_effect=drive_step), patch.object(
+        mgr, "_rewrite_sources", side_effect=drive_step
+    ), patch.object(
+        mgr, "remove_obsolete_kernels", return_value=ProcessResult(EXIT.OK)
+    ), patch(
+        "source.apt.apt_cli.get_os_data",
+        side_effect=[
+            debian_os_data("12", "bookworm"),
+            debian_os_data("13", "trixie"),
+        ],
+    ):
+        assert mgr.version_upgrade("13") == EXIT.OK
+
+    weights = (
+        (7, False),  # refresh before switching sources
+        (7, True),  # upgrade current release fully
+        (1, False),  # rewrite codename across apt sources
+        (9, False),  # refresh onto the new release
+        (22, True),  # upgrade onto the new release
+        (54, True),  # dist-upgrade across the release boundary
+    )
+    expected = []
+    done = 0
+    for weight, installs in weights:
+        start = done / 100 * RELEASE_UPGRADE_ALMOST_DONE
+        stop = (done + weight) / 100 * RELEASE_UPGRADE_ALMOST_DONE
+        expected.append((start, stop, installs))
+        done += weight
+
+    assert len(recorded) == len(expected) == 6
+    for (got_start, got_stop, got_installs), (
+        want_start,
+        want_stop,
+        want_installs,
+    ) in zip(recorded, expected):
+        assert got_start == pytest.approx(want_start)
+        assert got_stop == pytest.approx(want_stop)
+        assert got_installs == want_installs
 
 
 # ReleaseUpgradeTail: shaping the post-transaction scriptlet tail
@@ -1080,6 +1179,19 @@ def debian_os_data(release="12", codename="bookworm") -> dict[str, str]:
         "release": release,
         "codename": codename,
     }
+
+
+# PACMANCLI release-upgrade refusal (Arch is a rolling release)
+
+
+def test_pacman_release_upgrade_refuses() -> None:
+    """--version-upgrade on an Arch template must fail loudly rather than
+    fall through to the generic update path."""
+    from source.pacman.pacman_cli import PACMANCLI
+
+    mgr = PACMANCLI(logging.NullHandler(), logging.DEBUG, AgentType.VM)
+    with pytest.raises(NotImplementedError):
+        mgr._release_upgrade("rolling")
 
 
 # APTCLI in-qube guard (single-step, current codename must be present)

--- a/vmupdate/tests/test_version_upgrade_agent.py
+++ b/vmupdate/tests/test_version_upgrade_agent.py
@@ -1,0 +1,1227 @@
+#!/usr/bin/python3
+# coding=utf-8
+#
+# The Qubes OS Project, https://www.qubes-os.org
+#
+# Copyright (C) 2026  Qubes OS contributors
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+"""
+Unit tests for the in-VM distribution version-upgrade agent path.
+
+The agent modules use absolute ``source.*`` imports because inside a qube
+they run with the agent directory as the top-level package root (see
+``entrypoint.py``). We mirror that here by putting the agent directory on
+``sys.path`` so the agent can be imported and unit-tested in isolation, with
+``subprocess`` fully mocked -- no real package manager is ever invoked.
+"""
+
+import os
+import sys
+import logging
+import argparse
+
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+_AGENT_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir, "agent")
+)
+if _AGENT_DIR not in sys.path:
+    sys.path.insert(0, _AGENT_DIR)
+
+# pylint: disable=wrong-import-position,protected-access
+import entrypoint
+from source.dnf.dnf_cli import DNFCLI
+from source.apt.apt_cli import APTCLI
+from source.common.package_manager import PackageManager, AgentType
+from source.common.process_result import ProcessResult
+from source.common.exit_codes import EXIT
+from source.args import AgentArgs
+
+
+def _expected_sync_cmd(target) -> tuple[str, ...]:
+    return (
+        "dnf",
+        f"--releasever={target}",
+        "distro-sync",
+        "--best",
+        "--allowerasing",
+        "--assumeyes",
+    )
+
+
+def make_dnf_cli() -> DNFCLI:
+    """Build a DNFCLI without requiring a real dnf binary on the host."""
+    with patch("source.dnf.dnf_cli.shutil.which", return_value="/usr/bin/dnf"):
+        return DNFCLI(logging.NullHandler(), logging.DEBUG, AgentType.VM)
+
+
+def fedora_os_data(release="41") -> dict[str, str]:
+    return {"id": "fedora", "os_family": "RedHat", "release": release}
+
+
+def fedora_upgrade_os_data(current="41", upgraded="42") -> list[dict]:
+    """os_data sequence for a successful run: the pre-flight guard reads the
+    current release, the post-upgrade verification reads the new one."""
+    return [fedora_os_data(current), fedora_os_data(upgraded)]
+
+
+@pytest.fixture(autouse=True)
+def postinstall_calls(monkeypatch):
+    """Mock qubes.PostInstall RPC execution and record invocations."""
+    calls: list[list] = []
+
+    def fake_call(cmd, **_kwargs) -> int:
+        calls.append(cmd)
+        return 0
+
+    monkeypatch.setattr(
+        "source.common.package_manager.subprocess.call", fake_call
+    )
+    return calls
+
+
+# DNFCLI._release_upgrade -- happy path
+
+
+def test_version_upgrade_runs_clean_then_distro_sync() -> None:
+    mgr = make_dnf_cli()
+    calls = []
+
+    def fake_run_cmd(cmd, realtime=True) -> ProcessResult:
+        calls.append((tuple(cmd), realtime))
+        return ProcessResult(EXIT.OK)
+
+    with patch.object(mgr, "run_cmd", side_effect=fake_run_cmd), patch(
+        "source.dnf.dnf_cli.get_os_data", side_effect=fedora_upgrade_os_data()
+    ):
+        code = mgr.version_upgrade("42")
+
+    assert code == EXIT.OK
+    # Old-release cache is wiped (captured, not streamed) before the bump.
+    assert calls[0] == (("dnf", "clean", "all"), False)
+    sync_cmd, sync_realtime = calls[1]
+    assert sync_cmd == _expected_sync_cmd("42")
+    # distro-sync streams in real time so dom0 sees live output.
+    assert sync_realtime is True
+
+
+def test_version_upgrade_emits_progress_milestones(capsys) -> None:
+    mgr = make_dnf_cli()
+    with patch.object(
+        mgr, "run_cmd", return_value=ProcessResult(EXIT.OK)
+    ), patch(
+        "source.dnf.dnf_cli.get_os_data", side_effect=fedora_upgrade_os_data()
+    ):
+        mgr.version_upgrade("42")
+
+    # The progress contract QubeConnection._collect_stderr parses: bare floats
+    # terminated by 100.00.
+    assert capsys.readouterr().err.split() == ["0.00", "100.00"]
+
+
+def test_version_upgrade_skips_duplicate_final_milestone(capsys) -> None:
+    """When callback-driven progress (the API subclasses' ProgressReporter)
+    already reported 100, the explicit final milestone must not repeat it:
+    dom0 treats everything after the first 100 as error text, so a second
+    100 surfaces as a bogus "err: 100.00" line."""
+    mgr = make_dnf_cli()
+    mgr.progress = SimpleNamespace(last_percent=100.0)
+    with patch.object(
+        mgr, "run_cmd", return_value=ProcessResult(EXIT.OK)
+    ), patch(
+        "source.dnf.dnf_cli.get_os_data", side_effect=fedora_upgrade_os_data()
+    ):
+        mgr.version_upgrade("42")
+
+    assert capsys.readouterr().err.split() == ["0.00"]
+
+
+def test_version_upgrade_completes_progress_that_fell_short(capsys) -> None:
+    """Callback-driven progress that stops shy of 100 (rounding in the
+    transaction callbacks) still needs the explicit completion milestone."""
+    mgr = make_dnf_cli()
+    mgr.progress = SimpleNamespace(last_percent=99.87)
+    with patch.object(
+        mgr, "run_cmd", return_value=ProcessResult(EXIT.OK)
+    ), patch(
+        "source.dnf.dnf_cli.get_os_data", side_effect=fedora_upgrade_os_data()
+    ):
+        mgr.version_upgrade("42")
+
+    assert capsys.readouterr().err.split() == ["0.00", "100.00"]
+
+
+def test_progress_reporter_remembers_last_reported_percent() -> None:
+    """ProgressReporter records the highest percent it emitted, so
+    PackageManager._finish_progress can tell whether 100 already went out."""
+    from source.common.progress_reporter import Progress, ProgressReporter
+
+    log = MagicMock()
+    reporter = ProgressReporter(
+        Progress(1, log),
+        Progress(1, log),
+        Progress(2, log),
+        callback=lambda percent: None,
+    )
+    assert reporter.last_percent == 0.0
+
+    # completing the update phase maps to that phase's stop percent (25)
+    reporter.update_progress.notify_callback(100)
+    assert reporter.last_percent == 25.0
+
+    reporter.upgrade_progress.notify_callback(100)
+    assert reporter.last_percent == 100.0
+
+
+def test_version_upgrade_release_bump_goes_through_distro_sync_seam() -> None:
+    """The release bump must route through `_distro_sync`: the dnf/dnf5 API
+    subclasses override that method to report fine-grained progress, so the
+    base flow may not bypass it."""
+    mgr = make_dnf_cli()
+    seam_calls = []
+
+    def fake_distro_sync(target) -> ProcessResult:
+        seam_calls.append(target)
+        return ProcessResult(EXIT.OK)
+
+    with patch.object(
+        mgr, "run_cmd", return_value=ProcessResult(EXIT.OK)
+    ) as run_cmd, patch.object(
+        mgr, "_distro_sync", side_effect=fake_distro_sync
+    ), patch(
+        "source.dnf.dnf_cli.get_os_data", side_effect=fedora_upgrade_os_data()
+    ):
+        code = mgr.version_upgrade("42")
+
+    assert code == EXIT.OK
+    assert seam_calls == ["42"]
+    # only the cache wipe still goes through run_cmd
+    assert [tuple(c.args[0]) for c in run_cmd.call_args_list] == [
+        ("dnf", "clean", "all")
+    ]
+
+
+# DNFCLI._release_upgrade -- in-qube re-verification (single-step only)
+
+
+def test_version_upgrade_refuses_non_numeric_target() -> None:
+    mgr = make_dnf_cli()
+    with patch.object(mgr, "run_cmd") as run_cmd, patch(
+        "source.dnf.dnf_cli.get_os_data", return_value=fedora_os_data("41")
+    ):
+        code = mgr.version_upgrade("bookworm")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    run_cmd.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "target,current",
+    [
+        ("41", "41"),
+        ("40", "41"),
+        ("43", "41"),
+    ],
+)
+def test_version_upgrade_enforces_single_step(target, current) -> None:
+    mgr = make_dnf_cli()
+    with patch.object(mgr, "run_cmd") as run_cmd, patch(
+        "source.dnf.dnf_cli.get_os_data",
+        return_value=fedora_os_data(current),
+    ):
+        code = mgr.version_upgrade(target)
+
+    assert code == EXIT.ERR_VM_UPDATE
+    run_cmd.assert_not_called()
+
+
+def test_version_upgrade_allows_dotted_current_release() -> None:
+    # VERSION_ID like "41.20240101" should compare on the major component.
+    mgr = make_dnf_cli()
+    with patch.object(
+        mgr, "run_cmd", return_value=ProcessResult(EXIT.OK)
+    ) as run_cmd, patch(
+        "source.dnf.dnf_cli.get_os_data",
+        side_effect=fedora_upgrade_os_data("41.20240101", "42.20250101"),
+    ):
+        code = mgr.version_upgrade("42")
+
+    assert code == EXIT.OK
+    assert run_cmd.call_count == 2
+
+
+# DNFCLI._release_upgrade -- failure mapping
+
+
+def test_version_upgrade_bails_when_clean_fails() -> None:
+    mgr = make_dnf_cli()
+    calls = []
+
+    def fake_run_cmd(cmd, realtime=True) -> ProcessResult:
+        calls.append(tuple(cmd))
+        return ProcessResult(3)  # clean all fails
+
+    with patch.object(mgr, "run_cmd", side_effect=fake_run_cmd), patch(
+        "source.dnf.dnf_cli.get_os_data", return_value=fedora_os_data("41")
+    ):
+        code = mgr.version_upgrade("42")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    # distro-sync is never attempted once the cache wipe fails.
+    assert calls == [("dnf", "clean", "all")]
+
+
+def test_version_upgrade_maps_distro_sync_failure() -> None:
+    mgr = make_dnf_cli()
+
+    def fake_run_cmd(cmd, realtime=True) -> ProcessResult:
+        if "distro-sync" in cmd:
+            return ProcessResult(7)  # arbitrary non-zero dnf failure
+        return ProcessResult(EXIT.OK)
+
+    with patch.object(mgr, "run_cmd", side_effect=fake_run_cmd), patch(
+        "source.dnf.dnf_cli.get_os_data", return_value=fedora_os_data("41")
+    ):
+        code = mgr.version_upgrade("42")
+
+    # Any non-zero is normalised to a dom0-handled VM error code.
+    assert code == EXIT.ERR_VM_UPDATE
+
+
+# DNFCLI._release_upgrade -- post-upgrade verification
+
+
+def test_version_upgrade_fails_when_release_did_not_move() -> None:
+    """Fail upgrade if os-release version did not change after distro-sync."""
+    mgr = make_dnf_cli()
+    with patch.object(
+        mgr, "run_cmd", return_value=ProcessResult(EXIT.OK)
+    ), patch(
+        "source.dnf.dnf_cli.get_os_data",
+        side_effect=fedora_upgrade_os_data("41", upgraded="41"),
+    ):
+        code = mgr.version_upgrade("42")
+
+    assert code == EXIT.ERR_VM_UPDATE
+
+
+def test_version_upgrade_fails_when_verification_unreadable() -> None:
+    mgr = make_dnf_cli()
+    with patch.object(
+        mgr, "run_cmd", return_value=ProcessResult(EXIT.OK)
+    ), patch(
+        "source.dnf.dnf_cli.get_os_data",
+        side_effect=[fedora_os_data("41"), OSError("os-release gone")],
+    ):
+        code = mgr.version_upgrade("42")
+
+    assert code == EXIT.ERR_VM_UPDATE
+
+
+# PackageManager.version_upgrade -- dom0 metadata notification
+
+
+def test_version_upgrade_notifies_dom0_after_success(
+    postinstall_calls,
+) -> None:
+    """A successful release upgrade must run qubes.PostInstall so dom0's
+    qvm-features (os-version/os-eol) and app menus refresh without waiting
+    for the next qube start."""
+    mgr = make_dnf_cli()
+    with patch.object(
+        mgr, "run_cmd", return_value=ProcessResult(EXIT.OK)
+    ), patch(
+        "source.dnf.dnf_cli.get_os_data",
+        side_effect=fedora_upgrade_os_data(),
+    ):
+        code = mgr.version_upgrade("42")
+
+    assert code == EXIT.OK
+    assert postinstall_calls == [["/etc/qubes-rpc/qubes.PostInstall"]]
+
+
+def test_version_upgrade_skips_notification_on_failure(
+    postinstall_calls,
+) -> None:
+    mgr = make_dnf_cli()
+    with patch.object(mgr, "run_cmd", return_value=ProcessResult(7)), patch(
+        "source.dnf.dnf_cli.get_os_data", return_value=fedora_os_data("41")
+    ):
+        code = mgr.version_upgrade("42")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    assert postinstall_calls == []
+
+
+def test_version_upgrade_notification_failure_is_nonfatal(
+    monkeypatch,
+) -> None:
+    """The upgrade itself succeeded; a broken/missing qubes.PostInstall only
+    delays the metadata refresh until next boot and must not fail the run."""
+    monkeypatch.setattr(
+        "source.common.package_manager.subprocess.call",
+        MagicMock(side_effect=FileNotFoundError("no such rpc")),
+    )
+    mgr = make_dnf_cli()
+    with patch.object(
+        mgr, "run_cmd", return_value=ProcessResult(EXIT.OK)
+    ), patch(
+        "source.dnf.dnf_cli.get_os_data",
+        side_effect=fedora_upgrade_os_data(),
+    ):
+        code = mgr.version_upgrade("42")
+
+    assert code == EXIT.OK
+
+
+# Base class -- fail-closed default for families without an implementation
+
+
+def test_base_version_upgrade_fails_loud() -> None:
+    mgr = PackageManager(logging.NullHandler(), logging.DEBUG, AgentType.VM)
+    with pytest.raises(NotImplementedError, match="not implemented"):
+        mgr._release_upgrade("42")
+    with pytest.raises(NotImplementedError, match="not implemented"):
+        mgr.version_upgrade("42")
+
+
+# Agent CLI surface -- args round-trip
+
+
+def _parse_agent_args(argv) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    AgentArgs.add_arguments(parser)
+    return parser.parse_args(argv)
+
+
+def test_version_upgrade_flag_round_trips_through_cli_args() -> None:
+    args = _parse_agent_args(["--version-upgrade", "42"])
+    assert args.version_upgrade == "42"
+
+    cli = AgentArgs.to_cli_args(args)
+    assert "--version-upgrade" in cli
+    assert cli[cli.index("--version-upgrade") + 1] == "42"
+
+
+def test_version_upgrade_flag_absent_by_default() -> None:
+    args = _parse_agent_args([])
+    assert args.version_upgrade is None
+
+    cli = AgentArgs.to_cli_args(args)
+    assert "--version-upgrade" not in cli
+    # Regression guard: a None-valued option must never leak a bare token.
+    assert None not in cli
+
+
+# Entrypoint dispatch
+
+
+def _patched_entrypoint(pkg_mng) -> tuple:
+    """Common patches so entrypoint.main runs without a real qube/logs."""
+    fake_logs = (MagicMock(), MagicMock(), logging.DEBUG, "", "")
+    return (
+        patch("entrypoint.init_logs", return_value=fake_logs),
+        patch("entrypoint.get_os_data", return_value=fedora_os_data("41")),
+        patch("entrypoint.get_package_manager", return_value=pkg_mng),
+        patch("entrypoint.os.system"),
+    )
+
+
+def test_entrypoint_dispatches_to_version_upgrade() -> None:
+    pkg_mng = MagicMock()
+    pkg_mng.version_upgrade.return_value = EXIT.OK
+    pkg_mng.clean.return_value = EXIT.OK
+
+    patches = _patched_entrypoint(pkg_mng)
+    with patches[0], patches[1], patches[2], patches[3]:
+        code = entrypoint.main(["--version-upgrade", "42"])
+
+    pkg_mng.version_upgrade.assert_called_once_with("42", print_streams=False)
+    pkg_mng.upgrade.assert_not_called()
+    assert code == EXIT.OK
+
+
+def test_entrypoint_maps_missing_version_upgrade_to_handled_error(
+    capsys,
+) -> None:
+    pkg_mng = MagicMock()
+    pkg_mng.version_upgrade.side_effect = NotImplementedError(
+        "Distribution version upgrade is not implemented for this package manager."
+    )
+    pkg_mng.clean.return_value = EXIT.OK
+
+    patches = _patched_entrypoint(pkg_mng)
+    with patches[0], patches[1], patches[2], patches[3]:
+        code = entrypoint.main(["--version-upgrade", "42"])
+
+    pkg_mng.version_upgrade.assert_called_once_with("42", print_streams=False)
+    pkg_mng.upgrade.assert_not_called()
+    assert code == EXIT.ERR_VM_UPDATE
+    assert "not implemented" in capsys.readouterr().err
+
+
+def test_entrypoint_runs_normal_update_without_flag() -> None:
+    pkg_mng = MagicMock()
+    pkg_mng.upgrade.return_value = EXIT.OK
+    pkg_mng.clean.return_value = EXIT.OK
+
+    patches = _patched_entrypoint(pkg_mng)
+    with patches[0], patches[1], patches[2], patches[3]:
+        code = entrypoint.main([])
+
+    pkg_mng.upgrade.assert_called_once()
+    pkg_mng.version_upgrade.assert_not_called()
+    assert code == EXIT.OK
+
+
+def test_entrypoint_skips_final_tick_for_version_upgrade(capsys) -> None:
+    """A CLI manager's version_upgrade() emits its own 0/100 milestones;
+    a second 100.00 from the entrypoint would reach dom0 as a stray
+    'err: 100.00' after the run already finished."""
+    pkg_mng = MagicMock()
+    pkg_mng.PROGRESS_REPORTING = False
+    pkg_mng.version_upgrade.return_value = EXIT.OK
+    pkg_mng.clean.return_value = EXIT.OK
+
+    patches = _patched_entrypoint(pkg_mng)
+    with patches[0], patches[1], patches[2], patches[3]:
+        code = entrypoint.main(["--version-upgrade", "42"])
+
+    assert code == EXIT.OK
+    assert "100.00" not in capsys.readouterr().err
+
+
+def test_entrypoint_prints_final_tick_for_normal_cli_update(capsys) -> None:
+    """Without --version-upgrade the fallback finished tick must remain."""
+    pkg_mng = MagicMock()
+    pkg_mng.PROGRESS_REPORTING = False
+    pkg_mng.upgrade.return_value = EXIT.OK
+    pkg_mng.clean.return_value = EXIT.OK
+
+    patches = _patched_entrypoint(pkg_mng)
+    with patches[0], patches[1], patches[2], patches[3]:
+        code = entrypoint.main([])
+
+    assert code == EXIT.OK
+    assert "100.00" in capsys.readouterr().err
+
+
+# APTCLI Debian release-upgrade path
+
+
+def test_apt_api_refresh_reloads_sources_before_update() -> None:
+    apt_api = pytest.importorskip("source.apt.apt_api")
+    mgr = apt_api.APT.__new__(apt_api.APT)
+    mgr.wait_for_lock = MagicMock()
+    mgr.apt_cache = MagicMock()
+    mgr.progress = MagicMock()
+    mgr.log = MagicMock()
+    calls = []
+
+    mgr.apt_cache.open.side_effect = lambda: calls.append("open")
+
+    def update(*_args, **_kwargs) -> bool:
+        calls.append("update")
+        return True
+
+    mgr.apt_cache.update.side_effect = update
+
+    result = mgr.refresh(hard_fail=True)
+
+    assert result.code == EXIT.OK
+    assert calls == ["open", "update", "open"]
+
+
+def test_apt_api_dist_upgrade_reports_preparation_phase(
+    tmp_path, capsys
+) -> None:
+    apt_api = pytest.importorskip("source.apt.apt_api")
+    mgr = apt_api.APT.__new__(apt_api.APT)
+    mgr.apt_cache = MagicMock()
+    mgr.progress = MagicMock()
+    mgr.log = MagicMock()
+
+    # apt_pkg.Configuration is a C extension object whose attributes
+    # (find_dir, set) are read-only, so patch the module-level apt_pkg
+    # reference instead of poking at config directly.
+    with patch.object(apt_api, "apt_pkg") as mock_apt_pkg:
+        mock_apt_pkg.config.find_dir.return_value = str(tmp_path)
+        result = mgr._dist_upgrade()
+
+    assert result.code == EXIT.OK
+    assert capsys.readouterr().out.splitlines() == [
+        "Preparing distribution upgrade; dependency calculation may take "
+        "some time...",
+        "Calculating package changes...",
+    ]
+    mgr.apt_cache.open.assert_called_once_with()
+    mgr.apt_cache.upgrade.assert_called_once_with(dist_upgrade=True)
+    mgr.apt_cache.commit.assert_called_once()
+    debug_calls = mgr.log.debug.call_args_list
+    debug_messages = [str(call.args[0]) for call in debug_calls]
+    assert any(
+        "cache reload before distribution upgrade" in message
+        for message in debug_messages
+    )
+    assert any(
+        "dependency calculation" in message for message in debug_messages
+    )
+    assert any("package commit" in message for message in debug_messages)
+
+
+def test_apt_api_fetch_progress_announces_every_transaction(capsys) -> None:
+    """A release upgrade commits three times through one FetchProgress."""
+    apt_api = pytest.importorskip("source.apt.apt_api")
+    progress = apt_api.FetchProgress(weight=48, log=MagicMock())
+    progress.notify_callback = MagicMock()
+
+    for _ in range(3):
+        progress.start()
+        progress.total_items = 90
+        progress.total_bytes = 285733027
+        progress.current_bytes = 1024
+        progress.pulse(None)
+        progress.pulse(None)
+        progress.stop()
+
+    out = capsys.readouterr().out
+    assert out.count("Fetching 90 packages") == 3
+
+
+def test_apt_api_fetch_progress_reports_during_long_download(capsys) -> None:
+    """The 954 MiB release-upgrade fetch must not go silent for minutes."""
+    apt_api = pytest.importorskip("source.apt.apt_api")
+    progress = apt_api.FetchProgress(weight=48, log=MagicMock())
+    progress.notify_callback = MagicMock()
+
+    # start() takes the first tick, then one per pulse; only the pulses at
+    # +30s and +39s past the last report clear REPORT_INTERVAL.
+    clock = [0.0, 1.0, 5.0, 31.0, 32.0, 70.0]
+    with patch.object(apt_api.time, "monotonic", side_effect=clock):
+        progress.start()
+        progress.total_items = 979
+        progress.total_bytes = 1000.0
+        progress.current_bytes = 100.0
+        for _ in range(len(clock) - 1):
+            progress.pulse(None)
+
+    out = capsys.readouterr().out
+    assert out.count("Fetching 979 packages") == 1
+    assert out.count("of 1000.00 B...") == 2
+
+
+# DNF API release-upgrade path
+
+
+def test_dnf_api_distro_sync_reports_preparation_phase(capsys) -> None:
+    """The dnf API _distro_sync must print the same preparation and
+    dependency-calculation notices the apt path does, so the user is not
+    staring at a blank terminal while fill_sack/resolve runs for minutes."""
+    dnf_api = pytest.importorskip("source.dnf.dnf_api")
+    mgr = dnf_api.DNF.__new__(dnf_api.DNF)
+    mgr.progress = MagicMock()
+    mgr.log = MagicMock()
+
+    base = MagicMock()
+    # base.transaction is truthy so the empty-transaction early return is
+    # skipped; its install_set iterates over nothing so sign_check is a no-op
+    base.transaction.install_set = []
+
+    with patch.object(
+        dnf_api.dnf.conf, "Conf", return_value=MagicMock()
+    ), patch.object(dnf_api.dnf, "Base", return_value=base):
+        result = mgr._distro_sync("42")
+
+    assert result.code == EXIT.OK
+    out_lines = capsys.readouterr().out.splitlines()
+    assert (
+        "Preparing distribution upgrade; dependency calculation may "
+        "take some time..." in out_lines
+    )
+    assert "Calculating package changes..." in out_lines
+
+    base.fill_sack.assert_called_once()
+    base.distro_sync.assert_called_once()
+    base.resolve.assert_called_once_with(allow_erasing=True)
+    base.download_packages.assert_called_once()
+    base.do_transaction.assert_called_once()
+
+    debug_messages = [str(c.args[0]) for c in mgr.log.debug.call_args_list]
+    assert any("fill_sack" in m for m in debug_messages)
+    assert any("dependency resolution" in m for m in debug_messages)
+    assert any("package download" in m for m in debug_messages)
+    assert any("transaction" in m for m in debug_messages)
+
+
+def test_dnf5_api_distro_sync_reports_preparation_phase(capsys) -> None:
+    """The libdnf5 API _distro_sync must match the dnf/apt preparation
+    notices so every release-upgrade backend gives the same user feedback."""
+    dnf5_api = pytest.importorskip("source.dnf.dnf5_api")
+    mgr = dnf5_api.DNF5.__new__(dnf5_api.DNF5)
+    mgr.progress = MagicMock()
+    mgr.log = MagicMock()
+
+    base = MagicMock()
+    repo_sack = MagicMock()
+    base.get_repo_sack.return_value = repo_sack
+
+    transaction = MagicMock()
+    transaction.get_transaction_packages_count.return_value = 1
+    transaction.check_gpg_signatures.return_value = True
+    transaction.run.return_value = transaction.TransactionRunResult_SUCCESS
+
+    goal = MagicMock()
+    goal.resolve.return_value = transaction
+
+    with patch.object(
+        dnf5_api.libdnf5.base, "Base", return_value=base
+    ), patch.object(
+        dnf5_api.libdnf5.repo, "DownloadCallbacksUniquePtr"
+    ), patch.object(
+        dnf5_api.libdnf5.rpm, "TransactionCallbacksUniquePtr"
+    ), patch.object(
+        dnf5_api, "Goal", return_value=goal
+    ):
+        result = mgr._distro_sync("42")
+
+    assert result.code == EXIT.OK
+    out_lines = capsys.readouterr().out.splitlines()
+    assert (
+        "Preparing distribution upgrade; dependency calculation may "
+        "take some time..." in out_lines
+    )
+    assert "Calculating package changes..." in out_lines
+
+    repo_sack.load_repos.assert_called_once()
+    transaction.download.assert_called_once()
+    transaction.run.assert_called_once()
+
+    debug_messages = [str(c.args[0]) for c in mgr.log.debug.call_args_list]
+    assert any("repo load" in m for m in debug_messages)
+    assert any("dependency resolution" in m for m in debug_messages)
+    assert any("package download" in m for m in debug_messages)
+    assert any("transaction" in m for m in debug_messages)
+
+
+def test_dnf5_fetch_progress_tolerates_unknown_sizes(capsys) -> None:
+    """libdnf5 reports unknown download sizes as -1: the fetch header must
+    not show a negative total (the fedora-08 run printed "Fetching 4
+    packages [-4.00 B]") and the percent math must not divide by zero."""
+    dnf5_api = pytest.importorskip("source.dnf.dnf5_api")
+    progress = dnf5_api.FetchProgress(weight=90, log=MagicMock())
+    progress.notify_callback = MagicMock()
+
+    for name in ("repo-a", "repo-b", "repo-c", "repo-d"):
+        progress.add_new_download(None, name, -1)
+    progress.progress(1, -1, 512.0)
+
+    out = capsys.readouterr().out
+    assert "Fetching 4 packages [0.00 B]" in out
+    assert "Fetching repo-a [unknown size]" in out
+    assert "-4.00 B" not in out and "-1.00 B" not in out
+
+
+def test_dnf5_fetch_percent_does_not_stall_on_a_growing_total() -> None:
+    """libdnf5 registers downloads progressively, so accumulating the total
+    as they arrive gives a denominator that grows with its own numerator:
+    the ratio flattens and, because notify_callback only moves forward, the
+    bar sticks. A recorded fedora 41 -> 42 run froze on 28.3% for 10m23s
+    that way. Knowing the total up front must keep the percent climbing."""
+    dnf5_api = pytest.importorskip("source.dnf.dnf5_api")
+    progress = dnf5_api.FetchProgress(weight=90, log=MagicMock())
+    reported: list[float] = []
+    progress.notify_callback = reported.append
+    progress.expect_bytes(1000.0)
+
+    # Ten packages of 100 B, registered one at a time and each downloaded
+    # before the next is announced -- the pattern that used to flatline.
+    for i in range(1, 11):
+        progress.add_new_download(None, f"pkg-{i}", 100.0)
+        progress.progress(i, 100.0, 100.0)
+
+    downloads = [p for p in reported if p > 0]
+    assert downloads == sorted(downloads)
+    assert downloads[-1] == 100.0
+    # The whole point: it climbs throughout instead of pinning early.
+    assert len(set(downloads)) == 10
+
+
+def test_dnf5_expect_bytes_ignores_a_useless_estimate() -> None:
+    """An estimate that is absent or too small must degrade to the
+    accumulated total, never pin the bar at 100 for the rest of the run."""
+    dnf5_api = pytest.importorskip("source.dnf.dnf5_api")
+    progress = dnf5_api.FetchProgress(weight=90, log=MagicMock())
+    progress.notify_callback = MagicMock()
+
+    progress.expect_bytes(0.0)  # libdnf5 told us nothing
+    progress.add_new_download(None, "pkg", 400.0)
+    assert progress.download_total == 400.0
+
+    progress.expect_bytes(100.0)  # an estimate below what we can see
+    assert progress.download_total == 400.0
+
+
+def test_dnf5_planned_download_bytes_survives_a_hostile_transaction() -> None:
+    """Return 0.0 when transaction package sizes cannot be retrieved."""
+    dnf5_api = pytest.importorskip("source.dnf.dnf5_api")
+    broken = MagicMock()
+    broken.get_transaction_packages.side_effect = AttributeError("nope")
+
+    assert dnf5_api.planned_download_bytes(broken, MagicMock()) == 0.0
+
+
+def test_dnf5_planned_download_bytes_skips_erasures(monkeypatch) -> None:
+    """Removed packages download nothing; counting them would inflate the
+    denominator and strand the bar short of the end."""
+    dnf5_api = pytest.importorskip("source.dnf.dnf5_api")
+
+    def item(size: float, inbound: bool) -> MagicMock:
+        entry = MagicMock()
+        entry.get_action.return_value = inbound
+        entry.get_package.return_value.get_download_size.return_value = size
+        return entry
+
+    transaction = MagicMock()
+    transaction.get_transaction_packages.return_value = [
+        item(300.0, True),
+        item(999.0, False),
+        item(700.0, True),
+    ]
+    monkeypatch.setattr(
+        dnf5_api.libdnf5.base.transaction,
+        "transaction_item_action_is_inbound",
+        bool,
+    )
+
+    assert dnf5_api.planned_download_bytes(transaction, MagicMock()) == 1000.0
+
+
+def test_dnf5_fetch_mirror_failure_without_metadata(capsys) -> None:
+    """libdnf5 passes metadata=None for plain package downloads; the
+    mirror-failure notice must not read "Fetching None failure"."""
+    dnf5_api = pytest.importorskip("source.dnf.dnf5_api")
+    progress = dnf5_api.FetchProgress(weight=90, log=MagicMock())
+    progress.notify_callback = MagicMock()
+    progress.add_new_download(None, "openh264-2.5.1", -1)
+
+    progress.mirror_failure(1, "Curl error (28)", "http://mirror", None)
+
+    out = capsys.readouterr().out
+    assert "Fetching package failure (openh264-2.5.1) Curl error (28)" in out
+    assert "None" not in out
+
+
+def make_apt_cli() -> APTCLI:
+    """Build an APTCLI without requiring a real apt on the host."""
+    mgr = APTCLI(logging.NullHandler(), logging.DEBUG, AgentType.VM)
+    codenames = {
+        "11": "bullseye",
+        "12": "bookworm",
+        "13": "trixie",
+        "14": "forky",
+        "15": "duke",
+    }
+    mgr._debian_codename = codenames.get
+    return mgr
+
+
+def debian_os_data(release="12", codename="bookworm") -> dict[str, str]:
+    return {
+        "id": "debian",
+        "os_family": "Debian",
+        "release": release,
+        "codename": codename,
+    }
+
+
+# APTCLI in-qube guard (single-step, current codename must be present)
+
+
+def _apt_guard(os_data, target) -> ProcessResult:
+    return make_apt_cli()._verify_release_upgrade(target, os_data)
+
+
+def test_apt_guard_does_not_recheck_os_family() -> None:
+    os_data = debian_os_data("12", "bookworm")
+    os_data["os_family"] = "Unknown"
+    assert _apt_guard(os_data, "13").code == EXIT.OK
+
+
+def test_apt_guard_refuses_non_numeric_target() -> None:
+    result = _apt_guard(debian_os_data("12", "bookworm"), "trixie")
+    assert result.code == EXIT.ERR_VM_UPDATE
+
+
+@pytest.mark.parametrize(
+    "target,current",
+    [
+        ("12", "12"),
+        ("11", "12"),
+        ("14", "12"),
+    ],
+)
+def test_apt_guard_enforces_single_step(target, current) -> None:
+    result = _apt_guard(debian_os_data(current, "bookworm"), target)
+    assert result.code == EXIT.ERR_VM_UPDATE
+
+
+def test_apt_guard_refuses_missing_codename() -> None:
+    os_data = {"id": "debian", "os_family": "Debian", "release": "12"}
+    assert _apt_guard(os_data, "13").code == EXIT.ERR_VM_UPDATE
+
+
+def test_apt_guard_passes_for_single_step_debian() -> None:
+    assert _apt_guard(debian_os_data("12", "bookworm"), "13").code == EXIT.OK
+
+
+def test_apt_reads_codename_from_distro_info(tmp_path) -> None:
+    releases = tmp_path / "debian.csv"
+    releases.write_text(
+        "version,codename,series,created,release,eol\n"
+        "14,Forky,forky,2025-08-09,2027-06-10,2030-06-10\n"
+        "15,Duke,duke,2027-08-01,,\n"
+    )
+
+    with patch.object(APTCLI, "DEBIAN_RELEASES_FILE", str(releases)):
+        assert APTCLI._debian_codename("14") == "forky"
+        # rows without a release date are unreleased (testing); offering
+        # them would dist-upgrade onto testing and then fail verification
+        assert APTCLI._debian_codename("15") is None
+        assert APTCLI._debian_codename("16") is None
+
+
+# APTCLI._release_upgrade composition (apt mocked at the step level)
+
+
+def _record_apt_steps(
+    mgr, calls: list[str], fail_on=None, cleanup_fail=False
+) -> None:
+    """Replace the composed steps with recorders."""
+
+    def refresh(hard_fail) -> ProcessResult:
+        calls.append("refresh")
+        return ProcessResult(EXIT.ERR if fail_on == "refresh" else EXIT.OK)
+
+    def upgrade_internal(remove_obsolete) -> ProcessResult:
+        calls.append("upgrade")
+        return ProcessResult(EXIT.ERR if fail_on == "upgrade" else EXIT.OK)
+
+    def dist_upgrade() -> ProcessResult:
+        calls.append("dist-upgrade")
+        return ProcessResult(EXIT.ERR if fail_on == "dist-upgrade" else EXIT.OK)
+
+    def rewrite(old_codename, new_codename) -> ProcessResult:
+        calls.append(f"rewrite:{old_codename}->{new_codename}")
+        return ProcessResult(EXIT.ERR if fail_on == "rewrite" else EXIT.OK)
+
+    def remove_obsolete_kernels() -> ProcessResult:
+        calls.append("kernel-cleanup")
+        return ProcessResult(EXIT.ERR_VM_CLEANUP if cleanup_fail else EXIT.OK)
+
+    mgr.refresh = refresh
+    mgr.upgrade_internal = upgrade_internal
+    mgr._dist_upgrade = dist_upgrade
+    mgr._rewrite_sources = rewrite
+    mgr.remove_obsolete_kernels = remove_obsolete_kernels
+
+
+@pytest.fixture
+def apt_sources(tmp_path):
+    """A sources.list naming the old codename, so _release_upgrade's
+    read-only pre-scan passes instead of reading the host's /etc/apt."""
+    sources = tmp_path / "sources.list"
+    sources.write_text("deb https://deb.debian.org/debian bookworm main\n")
+    with patch.object(APTCLI, "APT_SOURCE_GLOBS", (str(sources),)):
+        yield sources
+
+
+def test_apt_release_upgrade_happy_path_order(apt_sources, capsys) -> None:
+    mgr = make_apt_cli()
+    calls: list[str] = []
+    _record_apt_steps(mgr, calls)
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        side_effect=[
+            debian_os_data("12", "bookworm"),
+            debian_os_data("13", "trixie"),
+        ],
+    ):
+        code = mgr.version_upgrade("13")
+
+    assert code == EXIT.OK
+    assert calls == [
+        "refresh",
+        "upgrade",
+        "rewrite:bookworm->trixie",
+        "refresh",
+        "upgrade",
+        "dist-upgrade",
+        "kernel-cleanup",
+    ]
+    # the QubeConnection progress contract: bare floats, terminated by 100.00
+    assert capsys.readouterr().err.split() == ["0.00", "100.00"]
+
+
+def test_apt_release_upgrade_refuses_symbolic_sources(
+    apt_sources, capsys
+) -> None:
+    """Sources addressing the release symbolically (e.g. ``stable``)
+    mention no codename; the read-only pre-scan must refuse before the
+    refresh and full upgrade run, not after them."""
+    apt_sources.write_text("deb https://deb.debian.org/debian stable main\n")
+    mgr = make_apt_cli()
+    calls: list[str] = []
+    _record_apt_steps(mgr, calls)
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        return_value=debian_os_data("12", "bookworm"),
+    ):
+        code = mgr.version_upgrade("13")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    assert calls == []
+
+
+def test_apt_release_upgrade_can_be_retried_after_interruption(
+    apt_sources, capsys
+) -> None:
+    """A run interrupted after the sources rewrite left them naming only
+    the new codename; the pre-scan must let the retry proceed."""
+    apt_sources.write_text("deb https://deb.debian.org/debian trixie main\n")
+    mgr = make_apt_cli()
+    calls: list[str] = []
+    _record_apt_steps(mgr, calls)
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        side_effect=[
+            debian_os_data("12", "bookworm"),
+            debian_os_data("13", "trixie"),
+        ],
+    ):
+        code = mgr.version_upgrade("13")
+
+    assert code == EXIT.OK
+    assert "rewrite:bookworm->trixie" in calls
+
+
+def test_apt_release_upgrade_survives_kernel_cleanup_failure(
+    apt_sources, capsys
+) -> None:
+    # kernel cleanup failure after a successful release bump should not fail the upgrade
+    mgr = make_apt_cli()
+    calls: list[str] = []
+    _record_apt_steps(mgr, calls, cleanup_fail=True)
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        side_effect=[
+            debian_os_data("12", "bookworm"),
+            debian_os_data("13", "trixie"),
+        ],
+    ):
+        code = mgr.version_upgrade("13")
+
+    assert code == EXIT.OK
+    assert calls[-1] == "kernel-cleanup"
+    assert capsys.readouterr().err.split() == ["0.00", "100.00"]
+
+
+def test_apt_release_upgrade_bails_before_rewrite_when_update_fails(
+    apt_sources, capsys
+) -> None:
+    mgr = make_apt_cli()
+    calls: list[str] = []
+    _record_apt_steps(mgr, calls, fail_on="refresh")
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        return_value=debian_os_data("12", "bookworm"),
+    ):
+        code = mgr.version_upgrade("13")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    # first apt-get update fails: sources never rewritten, no dist-upgrade
+    assert calls == ["refresh"]
+    assert capsys.readouterr().err.split() == ["0.00"]
+
+
+def test_apt_release_upgrade_maps_dist_upgrade_failure(
+    apt_sources, capsys
+) -> None:
+    mgr = make_apt_cli()
+    calls: list[str] = []
+    _record_apt_steps(mgr, calls, fail_on="dist-upgrade")
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        return_value=debian_os_data("12", "bookworm"),
+    ):
+        code = mgr.version_upgrade("13")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    assert calls[-1] == "dist-upgrade"
+    assert "100.00" not in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "actual",
+    [
+        debian_os_data("12", "bookworm"),
+        debian_os_data("13", "bookworm"),
+    ],
+)
+def test_apt_release_upgrade_verifies_target_release(
+    actual, apt_sources, capsys
+) -> None:
+    mgr = make_apt_cli()
+    calls: list[str] = []
+    _record_apt_steps(mgr, calls)
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        side_effect=[debian_os_data("12", "bookworm"), actual],
+    ):
+        code = mgr.version_upgrade("13")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    assert calls[-1] == "dist-upgrade"
+    assert "kernel-cleanup" not in calls
+    assert "100.00" not in capsys.readouterr().err
+
+
+def test_apt_release_upgrade_guard_failure_short_circuits(capsys) -> None:
+    mgr = make_apt_cli()
+    calls: list[str] = []
+    _record_apt_steps(mgr, calls)
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        return_value=debian_os_data("12", ""),
+    ):
+        code = mgr.version_upgrade("13")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    assert not calls  # no apt call, no rewrite
+    assert not capsys.readouterr().err  # no progress emitted
+
+
+def test_apt_release_upgrade_refuses_unknown_target_codename(capsys) -> None:
+    mgr = make_apt_cli()
+    calls: list[str] = []
+    _record_apt_steps(mgr, calls)
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        return_value=debian_os_data("15", "duke"),
+    ):
+        code = mgr.version_upgrade("16")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    assert not calls
+    assert not capsys.readouterr().err
+
+
+def test_apt_release_upgrade_refuses_unreadable_release_data(capsys) -> None:
+    mgr = make_apt_cli()
+    mgr._debian_codename = MagicMock(side_effect=OSError("missing"))
+    calls: list[str] = []
+    _record_apt_steps(mgr, calls)
+    with patch(
+        "source.apt.apt_cli.get_os_data",
+        return_value=debian_os_data("12", "bookworm"),
+    ):
+        code = mgr.version_upgrade("13")
+
+    assert code == EXIT.ERR_VM_UPDATE
+    assert not calls
+    assert not capsys.readouterr().err
+
+
+# apt sources codename rewrite
+
+
+def test_apt_rewrites_list_and_deb822_sources(tmp_path) -> None:
+    mgr = make_apt_cli()
+    listd = tmp_path / "sources.list.d"
+    listd.mkdir()
+    main = tmp_path / "sources.list"
+    main.write_text("deb http://deb.debian.org/debian bookworm main\n")
+    qubes = listd / "qubes-r4.list"
+    qubes.write_text(
+        "deb [arch=amd64] https://deb.qubes-os.org/r4.2/vm bookworm main\n"
+    )
+    deb822 = listd / "debian.sources"
+    deb822.write_text(
+        "Types: deb\n"
+        "URIs: http://deb.debian.org/debian\n"
+        "Suites: bookworm bookworm-security bookworm-updates\n"
+        "Components: main\n"
+    )
+    untouched = listd / "thirdparty.list"
+    untouched.write_text("deb http://example.com/repo stable main\n")
+    before = untouched.read_text()
+
+    globs = (
+        str(main),
+        str(tmp_path / "absent.list"),  # missing files are skipped
+        str(listd / "*.list"),
+        str(listd / "*.sources"),
+    )
+    with patch.object(APTCLI, "APT_SOURCE_GLOBS", globs):
+        result = mgr._rewrite_sources("bookworm", "trixie")
+
+    assert result.code == EXIT.OK
+    assert main.read_text() == "deb http://deb.debian.org/debian trixie main\n"
+    assert "trixie" in qubes.read_text() and "bookworm" not in qubes.read_text()
+    assert "Suites: trixie trixie-security trixie-updates" in deb822.read_text()
+    # a file with no codename occurrence is left byte-identical
+    assert untouched.read_text() == before
+    # the atomic write-then-rename leaves no temp files behind
+    assert not list(tmp_path.rglob("*.tmp"))
+
+
+def test_apt_rewrite_refuses_when_no_source_uses_the_codename(tmp_path) -> None:
+    # symbolically addressed sources (e.g. `stable`) never mention the
+    # codename: the rewrite would be a no-op, so refuse rather than let the
+    # qube silently stay on the old release while dom0 stamps it upgraded
+    mgr = make_apt_cli()
+    listd = tmp_path / "sources.list.d"
+    listd.mkdir()
+    main = tmp_path / "sources.list"
+    main.write_text("deb http://deb.debian.org/debian stable main\n")
+    before = main.read_text()
+    globs = (str(main), str(listd / "*.list"), str(listd / "*.sources"))
+    with patch.object(APTCLI, "APT_SOURCE_GLOBS", globs):
+        result = mgr._rewrite_sources("bookworm", "trixie")
+
+    assert result.code == EXIT.ERR_VM_UPDATE
+    assert result.err.endswith(
+        "no apt source references codename 'bookworm'; refusing upgrade."
+    )
+    assert main.read_text() == before  # nothing written
+
+
+def test_apt_rewrite_accepts_already_rewritten_sources(tmp_path) -> None:
+    # a run interrupted after the rewrite leaves sources naming only the
+    # new codename: the retry's rewrite pass must count them as done, not
+    # refuse the whole upgrade
+    mgr = make_apt_cli()
+    main = tmp_path / "sources.list"
+    main.write_text("deb http://deb.debian.org/debian trixie main\n")
+    before = main.read_text()
+    with patch.object(APTCLI, "APT_SOURCE_GLOBS", (str(main),)):
+        result = mgr._rewrite_sources("bookworm", "trixie")
+
+    assert result.code == EXIT.OK
+    assert main.read_text() == before  # no spurious write

--- a/vmupdate/tests/test_version_upgrade_agent.py
+++ b/vmupdate/tests/test_version_upgrade_agent.py
@@ -52,6 +52,11 @@ from source.apt.apt_cli import APTCLI
 from source.common.package_manager import PackageManager, AgentType
 from source.common.process_result import ProcessResult
 from source.common.exit_codes import EXIT
+from source.common.progress_reporter import (
+    Progress,
+    ProgressReporter,
+    ReleaseUpgradeTail,
+)
 from source.args import AgentArgs
 
 
@@ -132,8 +137,9 @@ def test_version_upgrade_emits_progress_milestones(capsys) -> None:
         mgr.version_upgrade("42")
 
     # The progress contract QubeConnection._collect_stderr parses: bare floats
-    # terminated by 100.00.
-    assert capsys.readouterr().err.split() == ["0.00", "100.00"]
+    # terminated by 100.00. 99.50 lands before qubes.PostInstall, whose
+    # fstrim runs long enough that reporting 100 first would stall the bar.
+    assert capsys.readouterr().err.split() == ["0.00", "99.50", "100.00"]
 
 
 def test_version_upgrade_skips_duplicate_final_milestone(capsys) -> None:
@@ -171,8 +177,6 @@ def test_version_upgrade_completes_progress_that_fell_short(capsys) -> None:
 def test_progress_reporter_remembers_last_reported_percent() -> None:
     """ProgressReporter records the highest percent it emitted, so
     PackageManager._finish_progress can tell whether 100 already went out."""
-    from source.common.progress_reporter import Progress, ProgressReporter
-
     log = MagicMock()
     reporter = ProgressReporter(
         Progress(1, log),
@@ -188,6 +192,123 @@ def test_progress_reporter_remembers_last_reported_percent() -> None:
 
     reporter.upgrade_progress.notify_callback(100)
     assert reporter.last_percent == 100.0
+
+
+# ReleaseUpgradeTail: shaping the post-transaction scriptlet tail
+
+
+def _make_tail(weights=(0, 55, 45)):
+    """Build an armed ReleaseUpgradeTail over dnf5's phase weights.
+
+    :return: (tail, emitted) where `emitted` accumulates overall percents
+    """
+
+    class Tail(ReleaseUpgradeTail, Progress):
+        def __init__(self, weight, log) -> None:
+            Progress.__init__(self, weight, log)
+            ReleaseUpgradeTail.__init__(self)
+
+    log = MagicMock()
+    emitted: list[float] = []
+    update, fetch, upgrade = weights
+    tail = Tail(upgrade, log)
+    ProgressReporter(
+        Progress(update, log),
+        Progress(fetch, log),
+        tail,
+        callback=emitted.append,
+    )
+    tail.open_tail()
+    return tail, emitted
+
+
+def test_tail_inert_until_armed() -> None:
+    """Ordinary qubes-vm-update runs must be untouched: with the tail
+    closed, package callbacks are neither rescaled nor redirected."""
+    tail, emitted = _make_tail()
+    tail.close_tail()
+    tail.notify_callback(tail._scaled_percent(100))
+    # the upgrade phase owns 55..100, so an unscaled 100 reaches 100
+    assert emitted == [100.0]
+    tail.note_tail_scriptlet()
+    assert emitted == [100.0]
+
+
+def test_tail_rescales_package_progress_to_end_at_cap() -> None:
+    """Package callbacks are rescaled, not clamped: clamping pins the bar
+    for however long the elements past the cap take, which is the freeze
+    this shaping exists to remove."""
+    tail, emitted = _make_tail()
+    for local in (25, 50, 75, 100):
+        tail.notify_callback(tail._scaled_percent(local))
+
+    span = ReleaseUpgradeTail.CAP - 55
+    assert emitted == pytest.approx(
+        [55 + span * f for f in (0.25, 0.5, 0.75, 1.0)], abs=0.01
+    )
+
+
+def test_tail_never_reaches_its_ceiling() -> None:
+    """The scriptlet count cannot be known up front, so the band is
+    asymptotic: however many run, the bar stays below TAIL_STOP."""
+    tail, emitted = _make_tail()
+    for _ in range(500):
+        tail.note_tail_scriptlet()
+
+    assert emitted == sorted(emitted)
+    assert emitted[0] > ReleaseUpgradeTail.CAP
+    assert emitted[-1] < ReleaseUpgradeTail.TAIL_STOP
+    assert emitted[-1] > ReleaseUpgradeTail.TAIL_STOP - 0.5
+
+
+def test_tail_is_visible_on_a_one_decimal_bar() -> None:
+    """dom0 renders one decimal, so the band has to be wide enough that a
+    realistic scriptlet count produces distinct readings rather than one
+    frozen value."""
+    tail, emitted = _make_tail()
+    # 99 scriptlets, as measured on a fedora-42 to 43 template upgrade
+    for _ in range(99):
+        tail.note_tail_scriptlet()
+
+    assert len({f"{percent:.1f}" for percent in emitted}) > 50
+
+
+def test_dnf5_tail_marker_types_are_known() -> None:
+    """Verify expected libdnf5 transaction callback script types exist."""
+    libdnf5 = pytest.importorskip("libdnf5")
+    callbacks = libdnf5.rpm.TransactionCallbacks
+    assert isinstance(callbacks.ScriptType_POST_TRANSACTION, int)
+    # %postuntrans is rpm 4.20 and up, so absence is tolerated
+    from source.dnf.dnf5_api import tail_marker_types
+
+    assert callbacks.ScriptType_POST_TRANSACTION in tail_marker_types()
+
+
+def test_version_upgrade_final_milestone_follows_postinstall() -> None:
+    """100 must come after qubes.PostInstall: its fstrim runs long enough
+    that reporting 100 first leaves the bar apparently stuck."""
+    mgr = make_dnf_cli()
+    order: list[str] = []
+
+    def record_postinstall(_cmd, **_kwargs) -> int:
+        order.append("postinstall")
+        return 0
+
+    with patch.object(
+        mgr, "run_cmd", return_value=ProcessResult(EXIT.OK)
+    ), patch(
+        "source.dnf.dnf_cli.get_os_data", side_effect=fedora_upgrade_os_data()
+    ), patch(
+        "source.common.package_manager.subprocess.call",
+        side_effect=record_postinstall,
+    ), patch.object(
+        PackageManager,
+        "_report_progress",
+        staticmethod(lambda percent: order.append(f"{percent:.2f}")),
+    ):
+        mgr.version_upgrade("42")
+
+    assert order == ["0.00", "99.50", "postinstall", "100.00"]
 
 
 def test_version_upgrade_release_bump_goes_through_distro_sync_seam() -> None:
@@ -574,16 +695,6 @@ def test_apt_api_dist_upgrade_reports_preparation_phase(
     mgr.apt_cache.open.assert_called_once_with()
     mgr.apt_cache.upgrade.assert_called_once_with(dist_upgrade=True)
     mgr.apt_cache.commit.assert_called_once()
-    debug_calls = mgr.log.debug.call_args_list
-    debug_messages = [str(call.args[0]) for call in debug_calls]
-    assert any(
-        "cache reload before distribution upgrade" in message
-        for message in debug_messages
-    )
-    assert any(
-        "dependency calculation" in message for message in debug_messages
-    )
-    assert any("package commit" in message for message in debug_messages)
 
 
 def test_apt_api_fetch_progress_announces_every_transaction(capsys) -> None:
@@ -663,11 +774,50 @@ def test_dnf_api_distro_sync_reports_preparation_phase(capsys) -> None:
     base.download_packages.assert_called_once()
     base.do_transaction.assert_called_once()
 
-    debug_messages = [str(c.args[0]) for c in mgr.log.debug.call_args_list]
-    assert any("fill_sack" in m for m in debug_messages)
-    assert any("dependency resolution" in m for m in debug_messages)
-    assert any("package download" in m for m in debug_messages)
-    assert any("transaction" in m for m in debug_messages)
+
+def test_dnf_api_distro_sync_maps_errors_and_closes_base() -> None:
+    """A depsolve failure must surface as a handled ERR_VM_UPDATE result
+    (so dom0 rolls the clone back) and still close the dnf base."""
+    dnf_api = pytest.importorskip("source.dnf.dnf_api")
+    mgr = dnf_api.DNF.__new__(dnf_api.DNF)
+    mgr.progress = MagicMock()
+    mgr.log = MagicMock()
+
+    base = MagicMock()
+    base.resolve.side_effect = RuntimeError("depsolve failed")
+
+    with patch.object(
+        dnf_api.dnf.conf, "Conf", return_value=MagicMock()
+    ), patch.object(dnf_api.dnf, "Base", return_value=base):
+        result = mgr._distro_sync("42")
+
+    assert result.code == EXIT.ERR_VM_UPDATE
+    assert "depsolve failed" in result.err
+    base.close.assert_called_once()
+    base.download_packages.assert_not_called()
+    base.do_transaction.assert_not_called()
+
+
+def test_dnf_api_distro_sync_empty_transaction_is_success() -> None:
+    """An already-current clone (nothing to sync) is a success, not an
+    error, and must not attempt a download or a transaction."""
+    dnf_api = pytest.importorskip("source.dnf.dnf_api")
+    mgr = dnf_api.DNF.__new__(dnf_api.DNF)
+    mgr.progress = MagicMock()
+    mgr.log = MagicMock()
+
+    base = MagicMock()
+    base.transaction = None
+
+    with patch.object(
+        dnf_api.dnf.conf, "Conf", return_value=MagicMock()
+    ), patch.object(dnf_api.dnf, "Base", return_value=base):
+        result = mgr._distro_sync("42")
+
+    assert result.code == EXIT.OK
+    base.download_packages.assert_not_called()
+    base.do_transaction.assert_not_called()
+    base.close.assert_called_once()
 
 
 def test_dnf5_api_distro_sync_reports_preparation_phase(capsys) -> None:
@@ -712,12 +862,6 @@ def test_dnf5_api_distro_sync_reports_preparation_phase(capsys) -> None:
     repo_sack.load_repos.assert_called_once()
     transaction.download.assert_called_once()
     transaction.run.assert_called_once()
-
-    debug_messages = [str(c.args[0]) for c in mgr.log.debug.call_args_list]
-    assert any("repo load" in m for m in debug_messages)
-    assert any("dependency resolution" in m for m in debug_messages)
-    assert any("package download" in m for m in debug_messages)
-    assert any("transaction" in m for m in debug_messages)
 
 
 def test_dnf5_fetch_progress_tolerates_unknown_sizes(capsys) -> None:
@@ -976,7 +1120,7 @@ def test_apt_release_upgrade_happy_path_order(apt_sources, capsys) -> None:
         "kernel-cleanup",
     ]
     # the QubeConnection progress contract: bare floats, terminated by 100.00
-    assert capsys.readouterr().err.split() == ["0.00", "100.00"]
+    assert capsys.readouterr().err.split() == ["0.00", "99.50", "100.00"]
 
 
 def test_apt_release_upgrade_refuses_symbolic_sources(
@@ -1039,7 +1183,7 @@ def test_apt_release_upgrade_survives_kernel_cleanup_failure(
 
     assert code == EXIT.OK
     assert calls[-1] == "kernel-cleanup"
-    assert capsys.readouterr().err.split() == ["0.00", "100.00"]
+    assert capsys.readouterr().err.split() == ["0.00", "99.50", "100.00"]
 
 
 def test_apt_release_upgrade_bails_before_rewrite_when_update_fails(

--- a/vmupdate/tests/test_version_upgrade_agent.py
+++ b/vmupdate/tests/test_version_upgrade_agent.py
@@ -52,6 +52,7 @@ from source.apt.apt_cli import APTCLI
 from source.common.package_manager import PackageManager, AgentType
 from source.common.process_result import ProcessResult
 from source.common.exit_codes import EXIT
+from source.common.package_manager import RELEASE_UPGRADE_ALMOST_DONE
 from source.common.progress_reporter import (
     Progress,
     ProgressReporter,
@@ -192,6 +193,92 @@ def test_progress_reporter_remembers_last_reported_percent() -> None:
 
     reporter.upgrade_progress.notify_callback(100)
     assert reporter.last_percent == 100.0
+
+
+# ProgressReporter step ranges: one slice of the bar per upgrade step
+
+
+def _apt_style_reporter():
+    """Build a reporter with APT's phase weights."""
+    log = MagicMock()
+    emitted: list[float] = []
+    phases = (Progress(4, log), Progress(48, log), Progress(48, log))
+    reporter = ProgressReporter(*phases, callback=emitted.append)
+    return reporter, emitted
+
+
+def test_step_range_keeps_a_repeated_phase_off_100() -> None:
+    """APTCLI._release_upgrade runs the phases six times. Without a slice
+    per step the second one drives the bar to 100 and the monotonic guard
+    silences the remaining four."""
+    reporter, _ = _apt_style_reporter()
+    reporter.set_step_range(0.0, 20.0, installs=True)
+    # every apt commit() ends in finish_update() -> notify_callback(100)
+    reporter.upgrade_progress.notify_callback(100)
+    assert reporter.last_percent == 20.0
+
+    reporter.set_step_range(20.0, 40.0, installs=True)
+    reporter.upgrade_progress.notify_callback(100)
+    assert reporter.last_percent == 40.0
+
+
+def test_step_range_gives_the_whole_slice_to_the_active_phases() -> None:
+    """A refresh-only step drives just the update phase, whose weight is a
+    small fraction of the reporter. It still has to cross its own slice,
+    or the bar sits still for the whole apt update."""
+    reporter, _ = _apt_style_reporter()
+    reporter.set_step_range(10.0, 30.0, installs=False)
+    reporter.update_progress.notify_callback(100)
+    assert reporter.last_percent == 30.0
+
+    # an installing step splits its slice between fetch and install
+    reporter.set_step_range(30.0, 50.0, installs=True)
+    reporter.fetch_progress.notify_callback(100)
+    assert reporter.last_percent == 40.0
+    reporter.upgrade_progress.notify_callback(100)
+    assert reporter.last_percent == 50.0
+
+
+def test_apt_release_upgrade_bar_stays_below_100_throughout(
+    apt_sources, capfd
+) -> None:
+    """End to end over the real step list: the bar must climb and stop
+    short of 100 until qubes.PostInstall has run.
+
+    capfd, not capsys: ProgressReporter dups the real stdout/stderr fds.
+    """
+    mgr = make_apt_cli()
+    mgr.progress, emitted = _apt_style_reporter()
+
+    def drive_step(*_args, **_kwargs) -> ProcessResult:
+        # Stand in for a step that runs its phases to completion. Every
+        # phase is driven, including the ones the step did not claim, to
+        # prove a stale range cannot jump the bar.
+        mgr.progress.update_progress.notify_callback(100)
+        mgr.progress.fetch_progress.notify_callback(100)
+        mgr.progress.upgrade_progress.notify_callback(100)
+        return ProcessResult(EXIT.OK)
+
+    with patch.object(mgr, "refresh", side_effect=drive_step), patch.object(
+        mgr, "upgrade_internal", side_effect=drive_step
+    ), patch.object(mgr, "_dist_upgrade", side_effect=drive_step), patch.object(
+        mgr, "_rewrite_sources", side_effect=drive_step
+    ), patch.object(
+        mgr, "remove_obsolete_kernels", return_value=ProcessResult(EXIT.OK)
+    ), patch(
+        "source.apt.apt_cli.get_os_data",
+        side_effect=[
+            debian_os_data("12", "bookworm"),
+            debian_os_data("13", "trixie"),
+        ],
+    ):
+        assert mgr.version_upgrade("13") == EXIT.OK
+
+    assert emitted == sorted(emitted)
+    # the callback stream climbs to, but not past, the pre-PostInstall mark
+    assert max(emitted) == RELEASE_UPGRADE_ALMOST_DONE
+    # so the explicit milestone is redundant and only 100 is printed
+    assert capfd.readouterr().err.split() == ["0.00", "100.00"]
 
 
 # ReleaseUpgradeTail: shaping the post-transaction scriptlet tail

--- a/vmupdate/vmupdate.py
+++ b/vmupdate/vmupdate.py
@@ -51,7 +51,7 @@ def main(
         os.chown(LOGPATH, -1, gid)
         os.chmod(LOGPATH, 0o664)
     except (PermissionError, KeyError):
-        # do it on the best effort basis
+        # non-critical; ignore if it fails
         pass
 
     try:
@@ -260,6 +260,11 @@ def parse_args(args: list[str] | None, app: QubesBase) -> argparse.Namespace:
 
     if parsed_args.update_if_stale < 0:
         raise ArgumentError("Wrong value for --update-if-stale")
+
+    if getattr(parsed_args, "version_upgrade", None):
+        parser.error(
+            "--version-upgrade is only supported via qvm-template-upgrade"
+        )
 
     return parsed_args
 


### PR DESCRIPTION
This PR introduces the `qvm-template-upgrade` dom0 command-line utility, that performs an in-place N -> N+1 distribution upgrade of Debian and Fedora TemplateVM or StandaloneVM

fixes: https://github.com/qubesOS/qubes-issues/issues/8605
GSoC 2026 project: [Automate Template Version Upgrade](https://summerofcode.withgoogle.com/programs/2026/projects/vjESxjOp) 