### PR TITLE
Fix interrupting update

### DIFF
--- a/vmupdate/tests/conftest.py
+++ b/vmupdate/tests/conftest.py
@@ -145,7 +145,7 @@ def test_agent():
     return closure
 
 
-def generate_vm_variations(app, variations):
+def generate_vm_variations(app, variations, include_cancelled=False):
     """
     Generate all possible variations of vms for the given list of features.
     """
@@ -182,15 +182,27 @@ def generate_vm_variations(app, variations):
             FinalStatus.SUCCESS: set(),
             FinalStatus.NO_UPDATES: set(),
             FinalStatus.ERROR: set(),
-            FinalStatus.CANCELLED: set(),
-        },
+        }
+        | (
+            {
+                FinalStatus.CANCELLED: set(),
+            }
+            if include_cancelled
+            else {}
+        ),
         "has_template_updated": {
             FinalStatus.SUCCESS: set(),
             FinalStatus.NO_UPDATES: set(),
             FinalStatus.ERROR: set(),
-            FinalStatus.CANCELLED: set(),
             FinalStatus.UNKNOWN: set(),
-        },
+        }
+        | (
+            {
+                FinalStatus.CANCELLED: set(),
+            }
+            if include_cancelled
+            else {}
+        ),
     }
 
     klasses = list(reversed(sorted(list(domains["klass"].keys()))))

--- a/vmupdate/update_manager.py
+++ b/vmupdate/update_manager.py
@@ -112,6 +112,10 @@ class UpdateManager:
         progress_bar.close()
         self.log.info("Update Manager: Finished, collecting success info")
 
+        # inform caller about requested cancel, even if all requested targets were updated
+        if progress_bar.termination.value:
+            self.ret_code = EXIT.SIGINT
+
         stats = list(progress_bar.statuses.values())
         if FinalStatus.CANCELLED in stats:
             self.ret_code = max(self.ret_code, EXIT.SIGINT)

--- a/vmupdate/vmupdate.py
+++ b/vmupdate/vmupdate.py
@@ -93,6 +93,8 @@ def main(args=None, app=qubesadmin.Qubes()):
         no_updates = all(
             stat == FinalStatus.NO_UPDATES for stat in admin_status.values()
         )
+    if ret_code_admin == EXIT.SIGINT:
+        return EXIT.SIGINT
 
     # independent qubes first (TemplateVMs, StandaloneVMs)
     ret_code_independent, templ_statuses = run_update(
@@ -102,12 +104,16 @@ def main(args=None, app=qubesadmin.Qubes()):
         all(stat == FinalStatus.NO_UPDATES for stat in templ_statuses.values())
         and no_updates
     )
+    if ret_code_independent == EXIT.SIGINT:
+        return EXIT.SIGINT
     # then derived qubes (AppVMs...)
     ret_code_appvm, app_statuses = run_update(derived, args, log)
     no_updates = (
         all(stat == FinalStatus.NO_UPDATES for stat in app_statuses.values())
         and no_updates
     )
+    if ret_code_appvm == EXIT.SIGINT:
+        return EXIT.SIGINT
 
     ret_code_restart = apply_updates_to_appvm(
         args, independent, templ_statuses, app_statuses, log


### PR DESCRIPTION
When SIGINT is sent during last qube in a given group (admin,
template/standalone, derived), given group isn't really interrupted, so
none of the returned update status is FinalStatus.CANCELLED. This meant
that update cancel request was canceled in practice and the update
proceeded to the next group uninterrupted. And also that overall exit
code didn't inform about the cancellation request.

Fix this by returning EXIT.SIGINT if SIGINT was received, instead of
checking if any update was actually cancelled.  And then check for the
EXIT.SIGINT status between update groups.

Fixes QubesOS/qubes-issues#10900