### PR TITLE
Improve output of qvm-vm-update for not-to-update vms

### DIFF
--- a/vmupdate/vmupdate.py
+++ b/vmupdate/vmupdate.py
@@ -55,7 +55,8 @@ def main(args=None, app=qubesadmin.Qubes()):
 
     if not targets:
         if not args.quiet:
-            print("No qube selected for update")
+            print("No qube eligible for update. Try --force-update to ensure ",
+                  "all qubes are checked for new updates.")
         return EXIT.OK_NO_UPDATES if args.signal_no_updates else EXIT.OK
 
     admin = [target for target in targets if target.klass == "AdminVM"]

--- a/vmupdate/vmupdate.py
+++ b/vmupdate/vmupdate.py
@@ -55,8 +55,10 @@ def main(args=None, app=qubesadmin.Qubes()):
 
     if not targets:
         if not args.quiet:
-            print("No qube eligible for update. Try --force-update to ensure ",
-                  "all qubes are checked for new updates.")
+            print(
+                "No qube eligible for update. Try --force-update to ensure ",
+                "all qubes are checked for new updates.",
+            )
         return EXIT.OK_NO_UPDATES if args.signal_no_updates else EXIT.OK
 
     admin = [target for target in targets if target.klass == "AdminVM"]
@@ -338,8 +340,10 @@ def select_targets(targets, args) -> Set[qubesadmin.vm.QubesVM]:
 
         if skip_update or prohibit_start:
             if not args.quiet:
-                print("Skipped {}. Marked to skip updates or start prohibited",
-                      vm.name)
+                print(
+                    "Skipped {}. Marked to skip updates or start prohibited",
+                    vm.name,
+                )
             continue
 
         # there are updates available => select
@@ -351,16 +355,22 @@ def select_targets(targets, args) -> Set[qubesadmin.vm.QubesVM]:
         # and that's not true at this point => skip
         if args.update_if_available:
             if not args.quiet:
-                print("Skipped {}. No updates available or not recently ",
-                      "checked for updates.", vm.name)
+                print(
+                    "Skipped {}. No updates available or not recently ",
+                    "checked for updates.",
+                    vm.name,
+                )
             continue
 
         if is_stale(vm, expiration_period=args.update_if_stale):
             selected.add(vm)
         else:
             if not args.quiet:
-                print("Skipped {}. No updates available or last check still ",
-                      "within stale period.", vm.name)
+                print(
+                    "Skipped {}. No updates available or last check still ",
+                    "within stale period.",
+                    vm.name,
+                )
 
     return selected
 

--- a/vmupdate/vmupdate.py
+++ b/vmupdate/vmupdate.py
@@ -337,6 +337,9 @@ def select_targets(targets, args) -> Set[qubesadmin.vm.QubesVM]:
             skip_update = False
 
         if skip_update or prohibit_start:
+            if not args.quiet:
+                print("Skipped {}. Marked to skip updates or start prohibited",
+                      vm.name)
             continue
 
         # there are updates available => select
@@ -347,10 +350,17 @@ def select_targets(targets, args) -> Set[qubesadmin.vm.QubesVM]:
         # update vm only if there are updates available
         # and that's not true at this point => skip
         if args.update_if_available:
+            if not args.quiet:
+                print("Skipped {}. No updates available or not recently ",
+                      "checked for updates.", vm.name)
             continue
 
         if is_stale(vm, expiration_period=args.update_if_stale):
             selected.add(vm)
+        else:
+            if not args.quiet:
+                print("Skipped {}. No updates available or last check still ",
+                      "within stale period.", vm.name)
 
     return selected
 


### PR DESCRIPTION
The [first commit](53af3399d7262c5d8d75105fa60c237a74f6800a) might be sufficient to fix [the issue at hand](https://github.com/QubesOS/qubes-issues/issues/9749), but the [second](https://github.com/QubesOS/qubes-core-admin-linux/commit/d1ce2a2ce9b5831492a09462b1f5f19d12565c79) makes it more clear.

Please let me know if I missed some common code quality details. First commit in a while...

Closes https://github.com/QubesOS/qubes-issues/issues/9749