### PR TITLE
Disable systemd-homed-activate too

### DIFF
--- a/system-config/75-qubes-dom0.preset
+++ b/system-config/75-qubes-dom0.preset
@@ -11,6 +11,7 @@ disable systemd-timesyncd.service
 disable systemd-networkd.service
 disable systemd-resolved.service
 disable systemd-homed.service
+disable systemd-homed-activate.service
 disable chronyd.service
 
 # Locally-running services


### PR DESCRIPTION
systemd-homed is irrelevant in dom0. Disable the service to reduce
number of things potentially touching VM's disk images.
This may also help reducing some race conditions during LVM activation -
sometimes LVM complains it can't activate a volume due to metadata
volume being open.

QubesOS/qubes-issues#10236
