### PR TITLE
vmupdate: apply whonix settings when downloading dom0 updates

### DIFF
--- a/vmupdate/agent/source/dnf/dnf5_api.py
+++ b/vmupdate/agent/source/dnf/dnf5_api.py
@@ -49,6 +49,7 @@ class DNF5(DNFCLI):
         conf = self.base.get_config()
 
         if self.type == AgentType.UPDATE_VM:
+            self.configure_whonix_maybe(conf)
             conf.config_file_path = (
                 self.UPDATE_VM_INSTALLROOT + "/etc/dnf/dnf.conf"
             )

--- a/vmupdate/agent/source/dnf/dnf_api.py
+++ b/vmupdate/agent/source/dnf/dnf_api.py
@@ -50,6 +50,7 @@ class DNF(DNFCLI):
         conf.read(filename=dnfconf)
 
         if self.type == AgentType.UPDATE_VM:
+            self.configure_whonix_maybe(conf)
             conf.best = True
             conf.plugins = False
             conf.installroot = self.UPDATE_VM_INSTALLROOT

--- a/vmupdate/agent/source/dnf/dnf_cli.py
+++ b/vmupdate/agent/source/dnf/dnf_cli.py
@@ -21,6 +21,10 @@
 
 import shutil
 from typing import List
+import os
+import random
+import string
+import subprocess
 
 from source.common.package_manager import PackageManager, AgentType
 from source.common.process_result import ProcessResult
@@ -43,6 +47,51 @@ class DNFCLI(PackageManager):
             else:
                 raise RuntimeError("Package manager not found!")
         self.package_manager: str = pck_mngr
+
+    def configure_whonix_maybe(self, conf):
+        """
+        If running inside Whonix gateway, configure DNF options as Whonix
+        normally does. Ironically, the DNFCLI class is the only one not needing
+        any extra steps, because Whonix installs a wrapper at /usr/bin/dnf, but
+        using DNF (either DNF4 or DNF5) via API needs doing it separately.
+        Place this function here, as a common place for both DNF and DNF5
+        classes.
+        """
+        # based on condition to start tor in Whonix Gateway
+        if not os.path.exists("/usr/share/anon-gw-base-files/gateway"):
+            return
+        if not os.path.exists(
+            "/run/qubes/this-is-netvm"
+        ) and not os.path.exists("/run/qubes/this-is-proxyvm"):
+            return
+
+        # now we know it's Whonix Gateway
+        # apply custom steps of dnf uwt wrapper to the conf object
+        # try to keep in sync with https://github.com/Whonix/uwt/blob/master/usr/bin/dnf-3.anondist
+
+        if (
+            shutil.which("leaprun")
+            and subprocess.call(
+                ["leaprun", "--check", "try-wait-for-tor-service-running"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            == 0
+        ):
+            subprocess.check_call(
+                ["leaprun", "try-wait-for-tor-service-running"]
+            )
+        else:
+            subprocess.check_call(
+                ["/usr/libexec/helper-scripts/try-wait-for-tor-service-running"]
+            )
+
+        random_socks_password = "".join(
+            random.choices(string.ascii_letters + string.digits, k=43)
+        )
+        conf.proxy = "socks5h://127.0.0.1:9050/"
+        conf.proxy_username = "<torS0X>0"
+        conf.proxy_password = f"dnf-wrapper_{random_socks_password}"
 
     def refresh(self, hard_fail: bool) -> ProcessResult:
         """


### PR DESCRIPTION
Whonix Gateway adds a wrapper for /usr/bin/dnf, which adds proxy-related
options. This works fine as long as it's called as a standalone process,
but when qubes-vm-update calls DNF via Python API, the wrapper is
not used, and the options are not set. This way even generic uwtwrapper
is not used, which makes DNF attept connections directly (without any
proxy), which is (intentionally) blocked.

Fix this by adding the dnf's uwt wrapper logic into vmupdate code,
when it's using API. This basically covers two parts:
 - waiting for Tor daemon to be running
 - configuring dnf to use Tor as a proxy

Fixes QubesOS/qubes-issues#11034
