### PR TITLE
dom0: prefer 1920x1200 on StarFighter 4K panels

### DIFF
--- a/rpm_spec/core-dom0-linux.spec.in
+++ b/rpm_spec/core-dom0-linux.spec.in
@@ -161,6 +161,10 @@ install -m 755 -D system-config/kernel-grub2.install $RPM_BUILD_ROOT/usr/lib/ker
 install -m 755 -D system-config/kernel-xen-efi.install $RPM_BUILD_ROOT/usr/lib/kernel/install.d/90-xen-efi.install
 install -m 755 -D system-config/kernel-remove-bls.install $RPM_BUILD_ROOT/usr/lib/kernel/install.d/99-remove-bls.install
 install -m 755 -D system-config/zvol_is_qubes_volume $RPM_BUILD_ROOT%_prefix/lib/udev/zvol_is_qubes_volume
+install -m 0755 -D system-config/qubes-starfighter-display-quirk \
+    $RPM_BUILD_ROOT/usr/lib/qubes/qubes-starfighter-display-quirk
+install -m 0644 -D system-config/qubes-starfighter-display-quirk.service \
+    $RPM_BUILD_ROOT%_unitdir/qubes-starfighter-display-quirk.service
 install -m 644 -D system-config/75-qubes-dom0.preset \
     $RPM_BUILD_ROOT%_presetdir/75-qubes-dom0.preset
 install -m 644 -D system-config/75-qubes-dom0-user.preset \
@@ -215,6 +219,7 @@ set -eo pipefail
 
 systemctl --quiet enable qubes-suspend.service
 systemctl --quiet preset usbguard.service
+systemctl --quiet preset qubes-starfighter-display-quirk.service
 
 # migrate dom0-updates check disable flag
 if [ $1 -ge 2 ]; then
@@ -253,6 +258,8 @@ if [ "$1" = 0 ] ; then
 	# no more packages left
 
     systemctl disable qubes-suspend.service > /dev/null 2>&1
+    systemctl disable qubes-starfighter-display-quirk.service > /dev/null 2>&1
+    rm -f /etc/X11/xorg.conf.d/10-qubes-starfighter-4k.conf
 fi
 
 %triggerin -- PackageKit
@@ -316,6 +323,8 @@ chmod -x /etc/grub.d/10_linux
 %_udevrulesdir/11-qubes-ignore-zvol-devices.rules
 %_udevrulesdir/99z-qubes-mark-ready.rules
 %attr(0755,root,root) %_prefix/lib/udev/zvol_is_qubes_volume
+/usr/lib/qubes/qubes-starfighter-display-quirk
+%_unitdir/qubes-starfighter-display-quirk.service
 %attr(0644,root,root) /etc/cron.d/qubes-sync-clock.cron
 /etc/cron.daily/lvm-cleanup
 %config(noreplace) /etc/profile.d/zz-disable-lesspipe.sh

--- a/system-config/75-qubes-dom0.preset
+++ b/system-config/75-qubes-dom0.preset
@@ -70,6 +70,7 @@ enable qubes-setupdvm.service
 enable qubes-qrexec-policy-daemon.service
 enable qubes-preload-dispvm.service
 enable qubesd.service
+enable qubes-starfighter-display-quirk.service
 enable anti-evil-maid-unseal.service
 enable anti-evil-maid-check-mount-devs.service
 enable anti-evil-maid-seal.service

--- a/system-config/qubes-starfighter-display-quirk
+++ b/system-config/qubes-starfighter-display-quirk
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -eu
+
+CONF_DIR=/etc/X11/xorg.conf.d
+CONF_FILE="$CONF_DIR/10-qubes-starfighter-4k.conf"
+PREFERRED_MODE=1920x1200
+NATIVE_MODE=3840x2400
+
+read_dmi() {
+    cat "/sys/class/dmi/id/$1" 2>/dev/null || true
+}
+
+remove_quirk() {
+    rm -f "$CONF_FILE"
+}
+
+if [ "$(read_dmi sys_vendor)" != "Star Labs" ] ||
+        [ "$(read_dmi product_name)" != "StarFighter" ]; then
+    remove_quirk
+    exit 0
+fi
+
+OUTPUT=
+for modes in /sys/class/drm/*-eDP-*/modes; do
+    [ -f "$modes" ] || continue
+    grep -qx "$NATIVE_MODE" "$modes" || continue
+
+    output=${modes%/modes}
+    output=${output##*/}
+    output=${output#card*-}
+    OUTPUT=$output
+    break
+done
+
+if [ -z "$OUTPUT" ]; then
+    remove_quirk
+    exit 0
+fi
+
+install -d -m 0755 "$CONF_DIR"
+
+cat > "$CONF_FILE" <<EOF
+Section "Monitor"
+    Identifier "$OUTPUT"
+    Option "PreferredMode" "$PREFERRED_MODE"
+EndSection
+EOF

--- a/system-config/qubes-starfighter-display-quirk.service
+++ b/system-config/qubes-starfighter-display-quirk.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Apply StarFighter 4K dom0 display quirk
+DefaultDependencies=no
+After=local-fs.target
+Before=display-manager.service
+ConditionFirmware=smbios-field(sys_vendor$=Star*Labs)
+ConditionFirmware=smbios-field(product_name=StarFighter)
+ConditionPathExistsGlob=/sys/class/drm/*-eDP-*/modes
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/qubes/qubes-starfighter-display-quirk
+
+[Install]
+WantedBy=graphical.target


### PR DESCRIPTION
## Summary

Add a dom0 oneshot service that runs before the display manager and writes an Xorg monitor snippet for Star Labs StarFighter systems whose eDP panel exposes a native 3840x2400 mode. The generated config sets Xorg's preferred mode to 1920x1200 while leaving the native mode available to users.

## Rationale

This is intended to replace the kernel-side draft in QubesOS/qubes-linux-kernel#1344. The affected system exposed only the native 3840x2400 mode through DRM, while Xorg listed the lower modes, so setting the default at the Xorg layer should match where the selectable mode actually exists.

## Runtime testing

Not runtime-tested on affected Qubes hardware yet; opening as a draft for review of the approach and packaging location.